### PR TITLE
to add polkadot.md

### DIFF
--- a/polkadot.md
+++ b/polkadot.md
@@ -1,0 +1,162 @@
+---
+namespace-identifier: polkadot
+title: Polkadot Namespace
+author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
+discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
+status: Draft
+type: Standard
+created: 2020-04-01
+updated: 2020-04-02
+requires: ["CAIP-2", "CAIP-10"]
+updates: CAIP-13
+---
+
+# Polkadot Namespace
+
+## Introduction
+
+This document defines the syntax and canonical references of the CASA URI scheme
+for the Polkadot namespace.
+
+## CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+### Context
+
+The namespace is called "polkadot" to refer to Polkadot-like "parachains,"
+parallel and independent Layer 1s coordinated by the Polkadot relay chain.
+
+### Reference Definition
+
+The definition for this namespace will use the `genesis-hash` as an indentifier
+for different Polkadot chains. The format is a 32 character prefix of the block
+hash (lower case SHA256 hex).
+
+### Resolution Method
+
+To resolve a blockchain reference for the Polkadot namespace, make a JSON-RPC
+request to the blockchain node with method `chain_getBlockHash`, for example:
+
+```jsonc
+// Request
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "chain_getBlockHash",
+  "params": [0]
+}
+
+// Response
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+}
+```
+The response will return as a value for the result a hash for the block with
+height 0 that should be sliced to its first 16 bytes (32 characters for base 16)
+to be CAIP-2/CAIP-10 compatible.
+
+### Rationale
+
+The rationale behind the use of block hash from the genesis block stems from its
+usage in the Polkadot architecture in network and consensus.  Collision risk was not considered significant .
+
+### Backwards Compatibility
+
+Not applicable
+
+### Test Cases
+
+This is a list of manually composed examples
+
+```
+# Kusama
+polkadot:b0a8d493285c2df73290dfb7e61f870f
+
+# Edgeware
+polkadot:742a2ca70c2fda6cee4f8df98d64c4c6
+
+# Kulupu
+polkadot:37e1f8125397a98630013a4dff89b54c
+```
+
+## CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+### Rationale
+
+Polkadot addresses can be expressed a number of ways, but the default form is a
+base58 [multiaddress][] with a human-readable prefix of one or more characters.
+The specification defining these across the entire Polkadot namespace is
+[SS58][]; this specification summarizes the calculation of an address as
+`base58encode ( concat ( <address-type>, <address>, <checksum> ) )`, where
+`<address-type>` is a prefix registered in the [SS58 registry][] and where
+`<checksum>` options are constrained by targeted output-length.
+
+While the above describes a given keypair as generating many addresses per
+network, a 47-character multiaddress is the default expression, unique per
+chain.  This was used to express addresses in CAIP-10, with other expressions
+out of scope of this specification. Similarly, recovery of chain ID from account
+type or validation of addresses using the included checksum are out of scope,
+although both are specified in [SS58][].
+
+### Syntax
+
+### Test Cases
+
+This is a list of examples composed using the [polkadot.subscan tool][]:
+
+```
+# Kusama
+//example address from [Polkadot-ENS tutorial][]:
+polkadot:b0a8d493285c2df73290dfb7e61f870f:CpjsLDC1JFyrhm3ftC9Gs4QoyrkHKhZKtK7YqGTRFtTafgp
+
+//one address in multiple network-specific expressions, taken from the [Polkadot address explainer][]:
+
+# Underlying Public Key:
+0x54a0lf789elcflcf69da4010f7001dfaea8e4166656f332ebb5b38ec85704811
+
+# Kusama (coordination chain; address-type prefix 0)
+polkadot:b0a8d493285c2df73290dfb7e61f870f:EVH78gP5ATklKjHonVpxM8c1W6rWPKn5cAS14fXn4Ry5NxK
+
+# Edgeware (address-type prefix 7)
+polkadot:742a2ca70c2fda6cee4f8df98d64c4c6:jRaQ6PPzcqNnckcLStwqrTjEvpKnJUP2Jw65Ut36LQQUycd
+
+# Kulupu (address-type prefix 16)
+polkadot:37e1f8125397a98630013a4dff89b54c:2dWWj2G2TEhvC9PnVEpAExrZ4J6yGx94imvGcdfkG2ko1u6x
+```
+
+## References
+
+- [Polkadot documentation][]: Homepage for ecosystem-wide developer documentation
+- [Polkadot-ENS tutorial][]: A tutorial for native Kusama address support in the ENS front-end
+- [Polkadot public RPC endpoints][]: for dev/testing purposes
+- [Polkadot identity system][]: Introduction to on-chain identity registrars 
+- [Polkadot address explainer][]: A quick overview of how network-specific,
+      self-describing addresses can derive from the same private key
+- [Polkadot subscan tool][]: A tool for transforming addresses according to SS58 across polkadot networks
+
+[Polkadot address explainer]: https://www.quora.com/How-do-different-wallet-addresses-work-on-Polkadot-and-Kusama
+[Polkadot identity system]: https://wiki.polkadot.network/docs/learn-identity
+[Polkadot public RPC endpoints]: https://wiki.polkadot.network/docs/maintain-endpoints
+[Polkadot documentation]: https://wiki.polkadot.network/
+[Polkadot subscan tool]: https://polkadot.subscan.io/tools/ss58_transform?
+[Polkadot-ENS tutorial]: https://wiki.polkadot.network/docs/ens
+[SS58]: https://docs.substrate.io/v3/advanced/ss58/
+[SS58 registry]: https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+[multiaddress]: https://github.com/multiformats/multiaddr#specification
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[CAIP-21]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-21.md
+[CAIP-22]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md
+[EIP155]: https://eips.ethereum.org/EIPS/eip-155
+[ERC20]: https://eips.ethereum.org/EIPS/eip-20
+[ERC721]: https://eips.ethereum.org/EIPS/eip-721
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/polkadot.md
+++ b/polkadot.md
@@ -61,7 +61,12 @@ to be CAIP-2/CAIP-10 compatible.
 ### Rationale
 
 The rationale behind the use of block hash from the genesis block stems from its
-usage in the Polkadot architecture in network and consensus.  Collision risk was not considered significant .
+usage in the Polkadot architecture in network and consensus.
+
+### Syntax
+
+As CAIP-2 references for this namespace are 32-byte SHA256 hashes in lowercase
+hex, they can be validated with the simple regular expression: `[0-9a-f]{32}`
 
 ### Backwards Compatibility
 
@@ -104,6 +109,14 @@ type or validation of addresses using the included checksum are out of scope,
 although both are specified in [SS58][].
 
 ### Syntax
+
+As the default/standard expression of an address in Polkadot is a 47-character
+base58 string, the following regular expression can be used for validating
+addresses:
+
+```
+[1-9A-HJ-NP-Za-km-z]{47}
+```
 
 ### Test Cases
 

--- a/polkadot/README.md
+++ b/polkadot/README.md
@@ -1,0 +1,50 @@
+---
+namespace-identifier: polkadot
+title: Polkadot Namespace
+author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
+discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
+status: Draft
+type: Standard
+created: 2020-04-01
+updated: 2020-04-02
+supersedes: CAIP-13
+---
+
+# Polkadot Namespace
+
+## Introduction
+
+These documents defines the syntax and canonical references of the CASA URI schemes
+for the Polkadot namespace.
+
+## References
+
+- [Polkadot documentation][]: Homepage for ecosystem-wide developer documentation
+- [Polkadot-ENS tutorial][]: A tutorial for native Kusama address support in the ENS front-end
+- [Polkadot public RPC endpoints][]: for dev/testing purposes
+- [Polkadot identity system][]: Introduction to on-chain identity registrars 
+- [Polkadot address explainer][]: A quick overview of how network-specific,
+      self-describing addresses can derive from the same private key
+- [Polkadot subscan tool][]: A tool for transforming addresses according to SS58 across polkadot networks
+
+[Polkadot address explainer]: https://www.quora.com/How-do-different-wallet-addresses-work-on-Polkadot-and-Kusama
+[Polkadot identity system]: https://wiki.polkadot.network/docs/learn-identity
+[Polkadot public RPC endpoints]: https://wiki.polkadot.network/docs/maintain-endpoints
+[Polkadot documentation]: https://wiki.polkadot.network/
+[Polkadot subscan tool]: https://polkadot.subscan.io/tools/ss58_transform?
+[Polkadot-ENS tutorial]: https://wiki.polkadot.network/docs/ens
+[SS58]: https://docs.substrate.io/v3/advanced/ss58/
+[SS58 registry]: https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+[multiaddress]: https://github.com/multiformats/multiaddr#specification
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[CAIP-21]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-21.md
+[CAIP-22]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md
+[EIP155]: https://eips.ethereum.org/EIPS/eip-155
+[ERC20]: https://eips.ethereum.org/EIPS/eip-20
+[ERC721]: https://eips.ethereum.org/EIPS/eip-721
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/polkadot/README.md
+++ b/polkadot/README.md
@@ -14,7 +14,20 @@ replaces: CAIP-13
 ## Introduction
 
 These documents defines the syntax and canonical references of the CASA URI schemes
-for the Polkadot namespace.
+for the Polkadot namespace. 
+
+It is important for developers new to the ecosystem to know that unlike other
+namespaces, the exact execution environment, RPC methods, block sizes and other
+core features of a blockchain vary widely in a very layered and modular
+architecture based on "pallets" (Rust crates that extend the virtual machine and
+consensus). This creates an environment for complex "cross-chain" development
+between polkadots chains that may have shared security or common resources via
+coordination chains but also may not. Within the framework of the
+Cross-Consensus Messaging [XCM][], cross-chain interactions are enabled but a
+polkadot-wide meta-chain data model; moving beyond the "relative addressing" of
+earlier forms of the Polkadot-wide `Multilocation` type, addressing in the
+"absolute mode" introduced by XCM v3 is the starting point for CASA-style
+addressing. 
 
 ## References
 
@@ -25,6 +38,7 @@ for the Polkadot namespace.
 - [Polkadot address explainer][]: A quick overview of how network-specific,
       self-describing addresses can derive from the same private key
 - [Polkadot subscan tool][]: A tool for transforming addresses according to SS58 across polkadot networks
+- [XCM]: Cross Consensus Messaging defies an addressing network across 
 
 [Polkadot address explainer]: https://www.quora.com/How-do-different-wallet-addresses-work-on-Polkadot-and-Kusama
 [Polkadot identity system]: https://wiki.polkadot.network/docs/learn-identity

--- a/polkadot/README.md
+++ b/polkadot/README.md
@@ -1,6 +1,12 @@
 ---
 namespace-identifier: polkadot
 title: Polkadot Namespace
+author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
+status: Draft
+type: Informational
+created: 2020-04-01
+updated: 2022-03-27
+replaces: CAIP-13
 ---
 
 # Polkadot Namespace

--- a/polkadot/README.md
+++ b/polkadot/README.md
@@ -1,13 +1,6 @@
 ---
 namespace-identifier: polkadot
 title: Polkadot Namespace
-author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
-discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
-status: Draft
-type: Standard
-created: 2020-04-01
-updated: 2020-04-02
-supersedes: CAIP-13
 ---
 
 # Polkadot Namespace

--- a/polkadot/caip10.md
+++ b/polkadot/caip10.md
@@ -6,9 +6,9 @@ discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
 status: Draft
 type: Standard
 created: 2020-04-01
-updated: 2020-04-02
+updated: 2022-03-27
 requires: ["CAIP-2", "CAIP-10"]
-supersedes: CAIP-13
+replaces: CAIP-13
 ---
 
 # CAIP-10

--- a/polkadot/caip10.md
+++ b/polkadot/caip10.md
@@ -17,20 +17,21 @@ replaces: CAIP-13
 
 ## Rationale
 
-Polkadot addresses can be expressed a number of ways, but the default form is a
-base58 [multiaddress][] with a human-readable prefix of one or more characters.
-The specification defining these across the entire Polkadot namespace is
-[SS58][]; this specification summarizes the calculation of an address as
-`base58encode ( concat ( <address-type>, <address>, <checksum> ) )`, where
-`<address-type>` is a prefix registered in the [SS58 registry][] and where
-`<checksum>` options are constrained by targeted output-length.
+Polkadot wallets can be expressed a number of ways, but the canonical expression
+in polkadot development is a base58 [multiaddress][] with a human-readable
+prefix of one or more characters. The specification defining these across the
+entire Polkadot namespace is [SS58][]; this specification summarizes the
+calculation of an address as `base58encode ( concat ( <address-type>, <address>,
+<checksum> ) )`, where `<address-type>` is a prefix registered in the [SS58
+registry][] and where `<checksum>` options are constrained by targeted
+output-length.
 
 While the above describes a given keypair as generating many addresses per
 network, a 47-character multiaddress is the default expression, unique per
 chain.  Note that a single private key will thus produce different
-multiaddresses on each chain where it is used, so de-duplicating accounts in a
-multi-Polkadot context requires implementing full support for advanced SS58
-functions.
+multiaddresses on each chain where it is used, so de-duplicating Polkadot
+accounts in a multi-chain context may require implementing full support for
+advanced SS58 functions.
 
 As the default multi-address was used to express individual addresses in
 CAIP-10, other possible expressions are out of scope of this specification.

--- a/polkadot/caip10.md
+++ b/polkadot/caip10.md
@@ -11,7 +11,7 @@ requires: ["CAIP-2", "CAIP-10"]
 supersedes: CAIP-13
 ---
 
-# Context
+# CAIP-10
 
 *For context, see the [CAIP-10][] specification.*
 
@@ -27,10 +27,16 @@ The specification defining these across the entire Polkadot namespace is
 
 While the above describes a given keypair as generating many addresses per
 network, a 47-character multiaddress is the default expression, unique per
-chain.  This was used to express addresses in CAIP-10, with other expressions
-out of scope of this specification. Similarly, recovery of chain ID from account
-type or validation of addresses using the included checksum are out of scope,
-although both are specified in [SS58][].
+chain.  Note that a single private key will thus produce different
+multiaddresses on each chain where it is used, so de-duplicating accounts in a
+multi-Polkadot context requires implementing full support for advanced SS58
+functions.
+
+As the default multi-address was used to express individual addresses in
+CAIP-10, other possible expressions are out of scope of this specification.
+Similarly, recovery of chain ID from account type or validation of addresses
+using the included checksum are out of scope, although both are specified in
+[SS58][].
 
 ## Syntax
 
@@ -42,7 +48,7 @@ addresses:
 [1-9A-HJ-NP-Za-km-z]{47}
 ```
 
-### Test Cases
+## Test Cases
 
 This is a list of examples composed using the [polkadot.subscan tool][]:
 

--- a/polkadot/caip10.md
+++ b/polkadot/caip10.md
@@ -1,0 +1,99 @@
+---
+namespace-identifier: polkadot-caip10
+title: Polkadot Namespace - Addresses
+author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
+discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
+status: Draft
+type: Standard
+created: 2020-04-01
+updated: 2020-04-02
+requires: ["CAIP-2", "CAIP-10"]
+supersedes: CAIP-13
+---
+
+# Context
+
+*For context, see the [CAIP-10][] specification.*
+
+## Rationale
+
+Polkadot addresses can be expressed a number of ways, but the default form is a
+base58 [multiaddress][] with a human-readable prefix of one or more characters.
+The specification defining these across the entire Polkadot namespace is
+[SS58][]; this specification summarizes the calculation of an address as
+`base58encode ( concat ( <address-type>, <address>, <checksum> ) )`, where
+`<address-type>` is a prefix registered in the [SS58 registry][] and where
+`<checksum>` options are constrained by targeted output-length.
+
+While the above describes a given keypair as generating many addresses per
+network, a 47-character multiaddress is the default expression, unique per
+chain.  This was used to express addresses in CAIP-10, with other expressions
+out of scope of this specification. Similarly, recovery of chain ID from account
+type or validation of addresses using the included checksum are out of scope,
+although both are specified in [SS58][].
+
+## Syntax
+
+As the default/standard expression of an address in Polkadot is a 47-character
+base58 string, the following regular expression can be used for validating
+addresses:
+
+```
+[1-9A-HJ-NP-Za-km-z]{47}
+```
+
+### Test Cases
+
+This is a list of examples composed using the [polkadot.subscan tool][]:
+
+```
+# Kusama
+//example address from [Polkadot-ENS tutorial][]:
+polkadot:b0a8d493285c2df73290dfb7e61f870f:CpjsLDC1JFyrhm3ftC9Gs4QoyrkHKhZKtK7YqGTRFtTafgp
+
+//one address in multiple network-specific expressions, taken from the [Polkadot address explainer][]:
+
+# Underlying Public Key:
+0x54a0lf789elcflcf69da4010f7001dfaea8e4166656f332ebb5b38ec85704811
+
+# Kusama (coordination chain; address-type prefix 0)
+polkadot:b0a8d493285c2df73290dfb7e61f870f:EVH78gP5ATklKjHonVpxM8c1W6rWPKn5cAS14fXn4Ry5NxK
+
+# Edgeware (address-type prefix 7)
+polkadot:742a2ca70c2fda6cee4f8df98d64c4c6:jRaQ6PPzcqNnckcLStwqrTjEvpKnJUP2Jw65Ut36LQQUycd
+
+# Kulupu (address-type prefix 16)
+polkadot:37e1f8125397a98630013a4dff89b54c:2dWWj2G2TEhvC9PnVEpAExrZ4J6yGx94imvGcdfkG2ko1u6x
+```
+
+## References
+
+- [Polkadot documentation][]: Homepage for ecosystem-wide developer documentation
+- [Polkadot-ENS tutorial][]: A tutorial for native Kusama address support in the ENS front-end
+- [Polkadot public RPC endpoints][]: for dev/testing purposes
+- [Polkadot identity system][]: Introduction to on-chain identity registrars 
+- [Polkadot address explainer][]: A quick overview of how network-specific,
+      self-describing addresses can derive from the same private key
+- [Polkadot subscan tool][]: A tool for transforming addresses according to SS58 across polkadot networks
+
+[Polkadot address explainer]: https://www.quora.com/How-do-different-wallet-addresses-work-on-Polkadot-and-Kusama
+[Polkadot identity system]: https://wiki.polkadot.network/docs/learn-identity
+[Polkadot public RPC endpoints]: https://wiki.polkadot.network/docs/maintain-endpoints
+[Polkadot documentation]: https://wiki.polkadot.network/
+[Polkadot subscan tool]: https://polkadot.subscan.io/tools/ss58_transform?
+[Polkadot-ENS tutorial]: https://wiki.polkadot.network/docs/ens
+[SS58]: https://docs.substrate.io/v3/advanced/ss58/
+[SS58 registry]: https://github.com/paritytech/ss58-registry/blob/main/ss58-registry.json
+[multiaddress]: https://github.com/multiformats/multiaddr#specification
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[CAIP-21]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-21.md
+[CAIP-22]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md
+[EIP155]: https://eips.ethereum.org/EIPS/eip-155
+[ERC20]: https://eips.ethereum.org/EIPS/eip-20
+[ERC721]: https://eips.ethereum.org/EIPS/eip-721
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/polkadot/caip2.md
+++ b/polkadot/caip2.md
@@ -11,20 +11,28 @@ requires: CAIP-2
 supersedes: CAIP-13
 ---
 
-# Context
+# CAIP-2
 
 *For context, see the [CAIP-2][] specification.*
+
+## Rationale
 
 The namespace is called "polkadot" to refer to Polkadot-like "parachains,"
 parallel and independent Layer 1s coordinated by the Polkadot relay chains.
 
-## Reference Definition
+The rationale behind the use of block hash from the genesis block stems from its
+usage in the Polkadot architecture in network and consensus.
+
+## Syntax
 
 The definition for this namespace will use the `genesis-hash` as an indentifier
 for different Polkadot chains. The format is a 32 character prefix of the block
 hash (lower case SHA256 hex).
 
-## Resolution Method
+As CAIP-2 references for this namespace are 32-byte SHA256 hashes in lowercase
+hex, they can be validated with the simple regular expression: `[0-9a-f]{32}`
+
+### Resolution Method
 
 To resolve a blockchain reference for the Polkadot namespace, make a JSON-RPC
 request to the blockchain node with method `chain_getBlockHash`, for example:
@@ -49,21 +57,11 @@ The response will return as a value for the result a hash for the block with
 height 0 that should be sliced to its first 16 bytes (32 characters for base 16)
 to be CAIP-2/CAIP-10 compatible.
 
-## Rationale
-
-The rationale behind the use of block hash from the genesis block stems from its
-usage in the Polkadot architecture in network and consensus.
-
-## Syntax
-
-As CAIP-2 references for this namespace are 32-byte SHA256 hashes in lowercase
-hex, they can be validated with the simple regular expression: `[0-9a-f]{32}`
-
 ### Backwards Compatibility
 
 Not applicable
 
-### Test Cases
+## Test Cases
 
 This is a list of manually composed examples
 

--- a/polkadot/caip2.md
+++ b/polkadot/caip2.md
@@ -17,8 +17,10 @@ replaces: CAIP-13
 
 ## Rationale
 
-The namespace is called "polkadot" to refer to Polkadot-like "parachains,"
-parallel and independent Layer 1s coordinated by the Polkadot relay chains.
+The namespace is called "polkadot" to encompass all chains in the polkadot
+ecosystem, allowing actors and entities to be addressable from core Polkadot
+"relay" chains, indepedent "solo" chains, and L2-like "parachains" coordinated
+by the Polkadot relay chains. 
 
 The rationale behind the use of block hash from the genesis block stems from its
 usage in the Polkadot architecture in network and consensus.
@@ -85,6 +87,7 @@ polkadot:37e1f8125397a98630013a4dff89b54c
 - [Polkadot address explainer][]: A quick overview of how network-specific,
       self-describing addresses can derive from the same private key
 - [Polkadot subscan tool][]: A tool for transforming addresses according to SS58 across polkadot networks
+- 
 
 [Polkadot address explainer]: https://www.quora.com/How-do-different-wallet-addresses-work-on-Polkadot-and-Kusama
 [Polkadot identity system]: https://wiki.polkadot.network/docs/learn-identity

--- a/polkadot/caip2.md
+++ b/polkadot/caip2.md
@@ -1,39 +1,30 @@
 ---
-namespace-identifier: polkadot
-title: Polkadot Namespace
+namespace-identifier: polkadot-caip2
+title: Polkadot Namespace - Chains
 author: ["Pedro Gomes (@pedrouid)", "Joshua Mir (@joshua-mir)", "Shawn Tabrizi (@shawntabrizi)", "Juan Caballero (@bumblefudge)"]
 discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
 status: Draft
 type: Standard
 created: 2020-04-01
 updated: 2020-04-02
-requires: ["CAIP-2", "CAIP-10"]
-updates: CAIP-13
+requires: CAIP-2
+supersedes: CAIP-13
 ---
 
-# Polkadot Namespace
-
-## Introduction
-
-This document defines the syntax and canonical references of the CASA URI scheme
-for the Polkadot namespace.
-
-## CAIP-2
+# Context
 
 *For context, see the [CAIP-2][] specification.*
 
-### Context
-
 The namespace is called "polkadot" to refer to Polkadot-like "parachains,"
-parallel and independent Layer 1s coordinated by the Polkadot relay chain.
+parallel and independent Layer 1s coordinated by the Polkadot relay chains.
 
-### Reference Definition
+## Reference Definition
 
 The definition for this namespace will use the `genesis-hash` as an indentifier
 for different Polkadot chains. The format is a 32 character prefix of the block
 hash (lower case SHA256 hex).
 
-### Resolution Method
+## Resolution Method
 
 To resolve a blockchain reference for the Polkadot namespace, make a JSON-RPC
 request to the blockchain node with method `chain_getBlockHash`, for example:
@@ -58,12 +49,12 @@ The response will return as a value for the result a hash for the block with
 height 0 that should be sliced to its first 16 bytes (32 characters for base 16)
 to be CAIP-2/CAIP-10 compatible.
 
-### Rationale
+## Rationale
 
 The rationale behind the use of block hash from the genesis block stems from its
 usage in the Polkadot architecture in network and consensus.
 
-### Syntax
+## Syntax
 
 As CAIP-2 references for this namespace are 32-byte SHA256 hashes in lowercase
 hex, they can be validated with the simple regular expression: `[0-9a-f]{32}`
@@ -85,61 +76,6 @@ polkadot:742a2ca70c2fda6cee4f8df98d64c4c6
 
 # Kulupu
 polkadot:37e1f8125397a98630013a4dff89b54c
-```
-
-## CAIP-10
-
-*For context, see the [CAIP-10][] specification.*
-
-### Rationale
-
-Polkadot addresses can be expressed a number of ways, but the default form is a
-base58 [multiaddress][] with a human-readable prefix of one or more characters.
-The specification defining these across the entire Polkadot namespace is
-[SS58][]; this specification summarizes the calculation of an address as
-`base58encode ( concat ( <address-type>, <address>, <checksum> ) )`, where
-`<address-type>` is a prefix registered in the [SS58 registry][] and where
-`<checksum>` options are constrained by targeted output-length.
-
-While the above describes a given keypair as generating many addresses per
-network, a 47-character multiaddress is the default expression, unique per
-chain.  This was used to express addresses in CAIP-10, with other expressions
-out of scope of this specification. Similarly, recovery of chain ID from account
-type or validation of addresses using the included checksum are out of scope,
-although both are specified in [SS58][].
-
-### Syntax
-
-As the default/standard expression of an address in Polkadot is a 47-character
-base58 string, the following regular expression can be used for validating
-addresses:
-
-```
-[1-9A-HJ-NP-Za-km-z]{47}
-```
-
-### Test Cases
-
-This is a list of examples composed using the [polkadot.subscan tool][]:
-
-```
-# Kusama
-//example address from [Polkadot-ENS tutorial][]:
-polkadot:b0a8d493285c2df73290dfb7e61f870f:CpjsLDC1JFyrhm3ftC9Gs4QoyrkHKhZKtK7YqGTRFtTafgp
-
-//one address in multiple network-specific expressions, taken from the [Polkadot address explainer][]:
-
-# Underlying Public Key:
-0x54a0lf789elcflcf69da4010f7001dfaea8e4166656f332ebb5b38ec85704811
-
-# Kusama (coordination chain; address-type prefix 0)
-polkadot:b0a8d493285c2df73290dfb7e61f870f:EVH78gP5ATklKjHonVpxM8c1W6rWPKn5cAS14fXn4Ry5NxK
-
-# Edgeware (address-type prefix 7)
-polkadot:742a2ca70c2fda6cee4f8df98d64c4c6:jRaQ6PPzcqNnckcLStwqrTjEvpKnJUP2Jw65Ut36LQQUycd
-
-# Kulupu (address-type prefix 16)
-polkadot:37e1f8125397a98630013a4dff89b54c:2dWWj2G2TEhvC9PnVEpAExrZ4J6yGx94imvGcdfkG2ko1u6x
 ```
 
 ## References

--- a/polkadot/caip2.md
+++ b/polkadot/caip2.md
@@ -6,9 +6,9 @@ discussions-to: https://github.com/ChainAgnostic/CAIPs/issues/13
 status: Draft
 type: Standard
 created: 2020-04-01
-updated: 2020-04-02
+updated: 2022-03-27
 requires: CAIP-2
-supersedes: CAIP-13
+replaces: CAIP-13
 ---
 
 # CAIP-2


### PR DESCRIPTION
I totally went out on a limb and defined CAIP-10 for this because it seemed so well-documented and straight-forward, although I had some questions:

1. Would it be clearer or more standard/intuitive for Polkadot developers to use the prefix registered in the SS58 directory as the chainID? if nothing else, it would shorten CAIP-10s
2. Even shorter would just be removing the chain reference from the CAIP-10s, since they are recoverable from the addresses! Is that... even an option, without updating CAIP-10?  If so, would they look like
`polkadot:EVH78gP5ATklKjHonVpxM8c1W6rWPKn5cAS14fXn4Ry5NxK`
or
`polkadot::EVH78gP5ATklKjHonVpxM8c1W6rWPKn5cAS14fXn4Ry5NxK`
?
3. I didn't even touch NFTs or assets, but maybe I should open a tracking issue for it?

CC @pedrouid @joshua-mir @shawntabrizi