### PR TITLE
to add arweave/README + caip2 + caip10 + caip122

### DIFF
--- a/arweave/README.md
+++ b/arweave/README.md
@@ -1,0 +1,24 @@
+---
+namespace-identifier: arweave
+title: Blockchain Reference for Arweave Namespace
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
+status: Draft
+type: Informational
+created: 2022-08-27
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# Namespace for Arweave chains
+
+This document describes the details of the Arweave network namespace and reference. 
+
+## References
+
+- [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/arweave/README.md
+++ b/arweave/README.md
@@ -17,7 +17,7 @@ This document describes the details of the Arweave network namespace and referen
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md) 
 
 ## Rights
 

--- a/arweave/README.md
+++ b/arweave/README.md
@@ -5,7 +5,7 @@ author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
 status: Draft
 type: Informational
 created: 2022-08-27
-requires: ["CAIP-2", "CAIP-10"]
+requires: ["CAIP-2", "CAIP-10", "CAIP-122"]
 ---
 
 # Namespace for Arweave chains
@@ -17,7 +17,7 @@ This document describes the details of the Arweave network namespace and referen
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
 
 ## Rights
 

--- a/arweave/README.md
+++ b/arweave/README.md
@@ -15,8 +15,8 @@ This document describes the details of the Arweave network namespace and referen
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
-- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
-- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 
 
 ## Rights

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -22,7 +22,7 @@ Particularities of syntax for Arweave "accounts" have been specified.
 
 ## Syntax
 
-Arweave addresses have a normalization of lowercase letters, uppercase letters, numbers and `-`s.
+Arweave addresses have a normalization of lowercase letters, uppercase letters, numbers and `-`s. The addresses are encoded in base64Url format.
 
 ### Backwards Compatibility
 
@@ -32,7 +32,7 @@ Not applicable.
 
 ```
 # Arweave mainnet
-ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
+arweave:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ```
 
 ## References

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -41,7 +41,7 @@ ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 - [Arweave Transaction Signing](https://docs.arweave.org/developers/server/http-api#transaction-signing)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)
 
 
 

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -38,8 +38,10 @@ ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [Arweave Transaction Signing](https://docs.arweave.org/developers/server/http-api#transaction-signing)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
 
 
 

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -1,7 +1,7 @@
 ---
 namespace-identifier: arweave-caip10
 title: Arweave Namespace - Addresses
-author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby), Dan MacDonald (@DanMacDonald)
 discussions-to:
 status: Draft
 type: Standard
@@ -32,12 +32,13 @@ Not applicable.
 
 ```
 # Arweave mainnet
-arweave:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
+arweave:7wIU7KolICAjClMl:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ```
 
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [Hash of Genesis Block](https://viewblock.io/arweave/block/0)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 - [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -32,7 +32,7 @@ Not applicable.
 
 ```
 # Arweave mainnet
-arweave:7wIU7KolICAjClMl:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
+arweave:7wIU:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ```
 
 ## References

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -38,7 +38,6 @@ ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
-- [Arweave Transaction Signing](https://docs.arweave.org/developers/server/http-api#transaction-signing)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 - [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -38,8 +38,8 @@ ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
-- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
-- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 
 
 

--- a/arweave/caip10.md
+++ b/arweave/caip10.md
@@ -1,0 +1,48 @@
+---
+namespace-identifier: arweave-caip10
+title: Arweave Namespace - Addresses
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
+discussions-to:
+status: Draft
+type: Standard
+created: 2022-09-01
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+## Abstract
+In CAIP-10 an account identification scheme is defined. This is the implementation of CAIP-10 for Arweave network.
+
+## Rationale
+
+Particularities of syntax for Arweave "accounts" have been specified.  
+
+## Syntax
+
+Arweave addresses have a normalization of lowercase letters, uppercase letters, numbers and `-`s.
+
+### Backwards Compatibility
+
+Not applicable.
+
+## Test Cases
+
+```
+# Arweave mainnet
+ar:1:kY9RAgTJEImkBpiKgVeXrsGV02T-D4dI3ZvSpnn7HSk
+```
+
+## References
+
+- [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+
+
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -31,14 +31,24 @@ Arweave signatures use the RSA-PSS signing algorithm to sign data and verify sig
 
 The abstract data model must be converted into a string representation in an unambigious format. We use the format as defined in EIP-4361 as reference.
 
+An informal template of the full message is presented below. The field descriptions are provided in the order they must appear as follows:
+- `domain` is the RFC 3986 authority that is requesting the signing.
+- `address` is the Arweave address performing the signing.
+- `uri` is an RFC 3986 URI referring to the resource that is the subject of the signing (as in the subject of a claim).
+- `version` is the current version of the message, which MUST be 1 for this specification.
+- `type` of the signature to be generated, as defined in the namespaces for this CAIP.
+- `signature` is the result of concatenation and signing of the other field descriptions by the wallet.
+
+Each message field is separated by a line feed (LF).
+
 ```
-Domain: ${domain}
-Address: ${address}
-URI: ${uri}
-Version: ${version}
-Chain ID: ${chain-id}
-Signature: ${signature}
-Type: ${type}
+Domain: ${domain} LF
+Address: ${address} LF
+URI: ${uri} LF
+Version: ${version} LF
+Chain ID: ${chain-id} LF
+Type: ${type} LF
+Signature: ${signature} LF
 ```
 
 ### Signature Verification

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -15,7 +15,7 @@ For context, see the [CAIP-122](CAIP-122) specification.
 
 ## Rationale
 
-On Arweave, [EIP-4361](EIP-4361) Sign-in with Arweave already exists, which was the inspiration for CAIP-122. This specification highlights how EIP-4361 conforms with CAIP-122.
+Arweave signatures are 512 byte arrays which are `Base64URL` encoded for transmission over HTTP. This specification provides the signing algorithm to use, the `type` of the signing algorithm to identify it, and a method for signature creation and verification as required by [CAIP-122](CAIP-122).
 
 ## Specification
 
@@ -34,21 +34,41 @@ The abstract data model must be converted into a string representation in an una
 An informal template of the full message is presented below. The field descriptions are provided in the order they must appear as follows:
 - `domain` is the RFC 3986 authority that is requesting the signing.
 - `address` is the Arweave address performing the signing.
+- `statement` (optional) is a human-readable ASCII assertion that the user will sign, and it must not contain '\n'.
 - `uri` is an RFC 3986 URI referring to the resource that is the subject of the signing (as in the subject of a claim).
 - `version` is the current version of the message, which MUST be 1 for this specification.
+- `chain-id` (optional) is the Arweave Chain ID to which the session is bound, and the network where Contract Accounts MUST be resolved.
+- `nonce` (optional) is a randomized token typically chosen by the relying party and used to prevent replay attacks, at least 8 alphanumeric characters.
+- `timestamp` (optional) is the unix time stamp of when the request was created.
+- `expiration-time` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message is no longer valid.
+- `not-before` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message will become valid.
+- `request-id` (optional) is an system-specific identifier that may be used to uniquely refer to the sign-in request.
+- `resources` (optional) is a list of information or references to information the user wishes to have resolved as part of authentication by the relying party. They are expressed as RFC 3986 URIs separated by "\n- " where \n is the byte 0x0a.
 - `type` of the signature to be generated, as defined in the namespaces for this CAIP.
 - `signature` is the result of concatenation and signing of the other field descriptions by the wallet.
 
-Each message field is separated by a line feed (LF).
-
 ```
-Domain: ${domain} LF
-Address: ${address} LF
-URI: ${uri} LF
-Version: ${version} LF
-Chain ID: ${chain-id} LF
-Type: ${type} LF
-Signature: ${signature} LF
+${domain} wants you to sign in with your Arweave account:
+${address}
+
+${statement}
+
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Nonce: ${nonce}
+Issued At: ${timestamp}
+Expiration Time: ${expiration-time}
+Not Before: ${not-before}
+Request ID: ${request-id}
+Resources:
+- ${resources[0]}
+- ${resources[1]}
+...
+- ${resources[n]}
+
+Type: ${type}
+Signature: ${signature}
 ```
 
 ### Signature Verification

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -25,7 +25,7 @@ Arweave wallets are RSA key pairs and use the private and public keys for signin
 
 ### Signature Type
 
-Arweave signatures use the RSA-PSS signing algorithm to sign data and verify signatures.
+Arweave signatures use the RSA-PSS signing algorithm to sign data and verify signatures. Hence, the type of the signature would be represented as `arweave:rsa-pss` in the cacao object.
 
 ### Signature Creation
 

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -1,0 +1,60 @@
+---
+namespace-identifier: arweave-caip122
+title: Arweave Namespace - SIWx
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby), Dan MacDonald (@DanMacDonald)
+discussions-to: TBA
+status: Draft
+type: Standard
+created: 2022-09-01
+requires: ["CAIP-122", "CAIP-2", "CAIP-10"]
+---
+
+## CAIP-122
+
+For context, see the [CAIP-122](CAIP-122) specification.
+
+## Rationale
+
+On Arweave, [EIP-4361](EIP-4361) Sign-in with Arweave already exists, which was the inspiration for CAIP-122. This specification highlights how EIP-4361 conforms with CAIP-122.
+
+## Specification
+
+### Signing Algorithm
+
+Arweave wallets are RSA key pairs and use the private and public keys for signing and verifying signatures. Arweave wallet addresses are the SHA-256 hash of the RSA public key.
+
+### Signature Type
+
+Arweave signatures use the RSA-PSS signing algorithm to sign data and verify signatures.
+
+### Signature Creation
+
+The abstract data model must be converted into a string representation in an unambigious format. We use the format as defined in EIP-4361 as reference.
+
+```
+Domain: ${domain}
+Address: ${address}
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Signature: ${signature}
+Type: ${type}
+```
+
+### Signature Verification
+
+The signature is encoded in Base64URL format. It must be decoded to an array of bytes before being verified using the RSA algorithm.
+
+## References
+
+- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Arweave
+- [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
+
+
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -57,7 +57,7 @@ The signature is encoded in Base64URL format. It must be decoded to an array of 
 
 ## References
 
-- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Arweave
+- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361)
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [Arweave Transaction Signing](https://docs.arweave.org/developers/server/http-api#transaction-signing)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -61,7 +61,7 @@ The signature is encoded in Base64URL format. It must be decoded to an array of 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)
 
 
 

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -71,7 +71,7 @@ Type: ${type}
 Signature: ${signature}
 ```
 
-The signature creation process on Arweave is done through the `arweave-js` library. The data model is JSON serialized to a string. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`.
+The signature creation process on Arweave is done through the `arweave-js` library. The message data model is expressed in string format. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`.
 
 ### Signature Verification
 

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -71,6 +71,8 @@ Type: ${type}
 Signature: ${signature}
 ```
 
+The signature creation process on Arweave is done through the `arweave-js` library. The data model is JSON serialized to a string. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`.
+
 ### Signature Verification
 
 The signature is encoded in Base64URL format. It must be decoded to an array of bytes before being verified using the RSA algorithm.

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -49,8 +49,8 @@ The signature is encoded in Base64URL format. It must be decoded to an array of 
 
 - [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Arweave
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
-- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
-- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 - [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
 
 

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -59,6 +59,7 @@ The signature is encoded in Base64URL format. It must be decoded to an array of 
 
 - [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361): Sign-In with Arweave
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [Arweave Transaction Signing](https://docs.arweave.org/developers/server/http-api#transaction-signing)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 - [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -1,7 +1,7 @@
 ---
 namespace-identifier: arweave-caip2
 title: Arweave Namespace - Chains
-author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby), Dan MacDonald (@DanMacDonald)
 discussions-to:
 status: Draft
 type: Standard
@@ -22,7 +22,7 @@ The namespace "arweave" refers to the wider Arweave ecosystem.
 
 #### Reference Definition
 
-The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `1`.
+The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `7wIU7KolICAjClMl` which is the reprresentation of the [hash of the genesis block](https://viewblock.io/arweave/block/0) truncated to the first 16 characters.
 
 
 ## Rationale
@@ -39,12 +39,13 @@ This is a manually composed example.
 
 ```
 # Arweave Mainnet
-arweave:1
+arweave:7wIU7KolICAjClMl
 ```
 
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [Hash of Genesis Block](https://viewblock.io/arweave/block/0)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 - [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -47,7 +47,7 @@ arweave:1
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md)
 
 
 

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -22,7 +22,7 @@ The namespace "arweave" refers to the wider Arweave ecosystem.
 
 #### Reference Definition
 
-The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `7wIU7KolICAjClMl` which is the reprresentation of the [hash of the genesis block](https://viewblock.io/arweave/block/0) truncated to the first 16 characters.
+The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `7wIU` which is the representation of the [hash of the genesis block](https://viewblock.io/arweave/block/0) truncated to the first 16 characters.
 
 
 ## Rationale

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -1,0 +1,55 @@
+---
+namespace-identifier: arweave-caip2
+title: Arweave Namespace - Chains
+author: Rohit Pathare (@ropats16), Phil Billingsby (@pbillingsby)
+discussions-to:
+status: Draft
+type: Standard
+created: 2022-09-01
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Abstract
+In CAIP-2 a general blockchain identification scheme is defined. This is the implementation of CAIP-2 for Arweave network.
+
+### Arweave Namespace
+
+The namespace "arweave" refers to the wider Arweave ecosystem.
+
+#### Reference Definition
+
+The reference relies on Arweave's current designation of addresses belonging to main networks by prefixing them with `1`.
+
+
+## Rationale
+
+Arweave has one blockchain, the [Blockweave](https://www.arweave.org/technology#blockweaves).
+
+## Backwards Compatibility
+
+Not applicable.
+
+## Test Cases
+
+This is a manually composed example.
+
+```
+# Arweave Mainnet
+arweave:1
+```
+
+## References
+
+- [Arweave](https://github.com/ArweaveTeam/arweave-standards)
+- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+
+
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -22,7 +22,7 @@ The namespace "arweave" refers to the wider Arweave ecosystem.
 
 #### Reference Definition
 
-The reference relies on Arweave's current designation of addresses belonging to main networks by prefixing them with `1`.
+The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `1`.
 
 
 ## Rationale

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -22,7 +22,7 @@ The namespace "arweave" refers to the wider Arweave ecosystem.
 
 #### Reference Definition
 
-The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `7wIU` which is the representation of the [hash of the genesis block](https://viewblock.io/arweave/block/0) truncated to the first 16 characters.
+The reference relies on Arweave's current designation of addresses belonging to main network by prefixing them with `7wIU` which is the representation of the [hash of the genesis block](https://viewblock.io/arweave/block/0) truncated to the first 4 characters.
 
 
 ## Rationale

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -47,6 +47,7 @@ arweave:1
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
 - [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
 - [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md): Sign in With X 
 
 
 

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -39,7 +39,7 @@ This is a manually composed example.
 
 ```
 # Arweave Mainnet
-arweave:7wIU7KolICAjClMl
+arweave:7wIU
 ```
 
 ## References

--- a/arweave/caip2.md
+++ b/arweave/caip2.md
@@ -45,8 +45,8 @@ arweave:1
 ## References
 
 - [Arweave](https://github.com/ArweaveTeam/arweave-standards)
-- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
-- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
 
 
 


### PR DESCRIPTION
Create a new namespace for arweave. 

Add support for:
- caip2 (Chains)
- caip10 (Addresses)
- caip122 (SIWX)