### PR TITLE
Add Sui Spec

### DIFF
--- a/sui/README.md
+++ b/sui/README.md
@@ -1,0 +1,29 @@
+---
+namespace-identifier: sui
+title: Sui Network
+author: zoz (@0xzoz)
+discussions-to:
+status: Draft
+type: Informational
+created: 2022-12-06
+updated: 2022-12-06
+---
+
+# Namespace for Sui 
+
+## Introduction
+
+This document describes the syntax and structure of the namespace for Sui..
+
+## Syntax
+
+The namespace "sui" refers to the Sui Network.
+
+## References
+
+[Sui Framework](https://docs.sui.io/reference/framework)
+[Sui RPC Reference](https://docs.sui.io/sui-jsonrpc): Important context on communicating with Sui nodes over RPC.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sui/caip2.md
+++ b/sui/caip2.md
@@ -1,0 +1,70 @@
+---
+caip: <to be assigned>
+title: Blockchain Reference for the Sui namespace
+author: zoz (@0xzoz)
+discussions-to: https://github.com/MystenLabs/sui/issues/6624
+status: Draft
+type: Standard
+created: 2022-12-06
+updated: 2021-12-06
+requires: 2
+---
+
+## Simple Summary
+
+This document is about the details of the Sui namespace and reference for
+CAIP-2.
+
+## Abstract
+
+In CAIP-2 a general blockchain identification scheme is defined. This is the
+implementation of CAIP-2 for `sui` (sui network).
+
+## Motivation
+
+See CAIP-2.
+
+### Sui Namespace
+
+The namespace `sui` refers to the Sui network.
+
+#### Reference Definition
+
+The reference relies on Sui's current network topology addresses being a single production network (mainnet), two persistent testing networks (testnet and devnet) and one refers to local development work (local).
+> Sui is in the stages of launching and this is to preempt mainnet when it lauches
+Reference should only be populated with `mainnet`, `testnet`, `devnet` and `local` symbols.
+
+### Resolution Method
+
+TBD
+
+## Rationale
+
+TBD 
+
+## Backwards Compatibility
+
+Not applicable
+
+## Test Cases
+
+This is a list of manually composed examples
+
+```
+# Sui mainnet
+sui:mainnet
+# Sui testnet
+sui:testnet
+# sui devnet
+sui:devnet
+```
+
+## Links
+
+- [CAIP-2](./caip-2.md) Blockchain ID Specification
+- [Sui Developer Documentation](https://docs.sui.io/)
+
+## Copyright
+
+Copyright and related rights waived
+via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This is to start the conversation as more information becomes available and to add [Sui Network](https://sui.io/) as a blockchain reference.

CAIP-2 was initially sent in [#190 in CAIP repository](https://github.com/ChainAgnostic/CAIPs/pull/190)