### PR TITLE
Add caip2 for edeXa

### DIFF
--- a/edeXa/README.md
+++ b/edeXa/README.md
@@ -1,0 +1,32 @@
+---
+namespace-identifier: edeXa
+title: Blockchain Reference for the edeXa Namespace
+author: Ranjith Kumar (@ranjith-edx), Shubham Koli (@shubham-edx)
+discussions-to: []
+status: Draft
+type: Informational
+created: 2023-01-19
+requires: 2
+---
+
+# Namespace for edeXa Blockchains
+
+This document defines the applicability of CAIP schemes to the blockchains of
+the edeXa business blockchain.edeXa Universe offers all well-known public blockchains in combination with our strong business blockchain technology to generate a new dimension of solutions
+
+## Syntax
+
+The namespace "edeXa" refers to the edeXa open-source blockchain platform.
+
+## References
+
+- [EIP155][]: Ethereum Improvement Proposal specifying generation and validation of ChainIDs
+- [edeXa RPC][]: https://chainlist.org/chain/1995
+- [Tezos RPC Interface][]: Important context on communicating with edeXa nodes over RPC.
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+
+
+## Rights
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/edeXa/caip2.md
+++ b/edeXa/caip2.md
@@ -1,0 +1,71 @@
+---
+namespace-identifier: edeXa
+title: Blockchain Reference for the edeXa Namespace
+author: Ranjith Kumar (@ranjith-edx), Shubham Koli (@shubham-edx)
+discussions-to: []
+status: Draft
+type: Standard
+created: 2023-01-19
+requires: 2
+---
+
+## Simple Summary
+
+This document is about the details of the edeXa namespace and reference for CAIP-2.
+
+## Abstract
+
+In CAIP-2 a general blockchain identification scheme is defined. This is the
+implementation of CAIP-2 for edeXa.
+
+## Motivation
+
+See CAIP-2.
+
+## Specification
+
+The JSON-RPC provider is able to make one or more JSON-RPC requests accompanied
+by a [CAIP-2][] compatible `chainId`
+
+### Resolution Method
+
+To resolve a blockchain reference for the EIP155 namespace, make a JSON-RPC
+request to a blockchain node with method `eth_chainId`, for example:
+
+```
+// Request
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "eth_chainId",
+  "params": []
+}
+// Response
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "0x7cb"
+}
+```
+
+The response will return a base-16-encoded integer that should be converted to
+base 10 to format an EIP155-compatible blockchain reference.
+
+## Test Cases
+
+This is a list of manually composed examples
+
+```
+# edeXa testnet
+edeXa:1995
+```
+
+## References
+
+- [EIP155][]: Ethereum Improvement Proposal specifying generation and validation of ChainIDs
+- [edeXa RPC][]: https://chainlist.org/chain/1995
+
+
+## Rights
+
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/edeXa/caip2.md
+++ b/edeXa/caip2.md
@@ -57,14 +57,12 @@ This is a list of manually composed examples
 
 ```
 # edeXa testnet
-edeXa:1995
+eip155:1995
 ```
-
 ## References
 
 - [EIP155][]: Ethereum Improvement Proposal specifying generation and validation of ChainIDs
 - [edeXa RPC][]: https://chainlist.org/chain/1995
-
 
 ## Rights
 


### PR DESCRIPTION
This PR adds a CAIP-2 definition for edeXa blockchain.

Reference of ChainAgnostic/CAIPs
#https://github.com/ChainAgnostic/CAIPs/pull/203