### PR TITLE
Fix Waves caip-10 test case for custom chain id

### DIFF
--- a/waves/caip10.md
+++ b/waves/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: waves-caip10
 title: Waves Namespace - Addresses
 author: Maxim Smolyakov (@msmolyakov), Yury Sidorov (@darksyd94)
-discussions-to: 
+discussions-to:
 status: Draft
 type: Standard
 created: 2023-01-19
@@ -73,7 +73,7 @@ waves:087:3PPPJ62chFkr7hQu34WLPwKiywCpeSbfap7
 waves:084:3NBNV8hiq8DTVF7UmzFLSUwud3h3pKZkVB3
 
 # Waves custom network (-7)
-waves:-07:3NBNV8hiq8DTVF7UmzFLSUwud3h3pKZkVB3
+waves:-07:4Wa91bcuNGyv4BdV52UJ2VdpRtvZTd4BZfm
 ```
 
 ## Links


### PR DESCRIPTION
I just noticed that the address is derived not from the specified Chain ID.