### PR TITLE
fix incorrect hash value in solana/caip19

### DIFF
--- a/solana/caip19.md
+++ b/solana/caip19.md
@@ -38,10 +38,10 @@ After the [CAIP-2][] (namespace+chainID), a slash defines an `asset_namespace` a
 
 ```
 # One Solana Mainnet NFT：Pesky Penguins #398
-solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ/token:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w
+solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w
 
 # Solana Mainnet USDC
-solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
 ```
 
 ## Links


### PR DESCRIPTION
As addressed in https://github.com/ChainAgnostic/namespaces/pull/61 and referenced in https://github.com/ChainAgnostic/namespaces/issues/60#issuecomment-1458440182, some existing documentation was referencing an incorrect hash. While fixes were made for CAIPs 2 and 10, no fix was made for 19.

This PR updates the mainnet genesis hash used in solana CAIP-19 to the correct value.