### PR TITLE
fix: reference link

### DIFF
--- a/eip155/caip2.md
+++ b/eip155/caip2.md
@@ -78,7 +78,7 @@ eip155:28945486
 - [ERC20][]: Basic [aka Fungible] Token Standard
 - [ERC721][]: Non-Fungible Token Standard
 
-[Chainid.network]: https://github.com/ethereum-lists/chains
+[ethereum-lists/chains]: https://github.com/ethereum-lists/chains
 [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
 [CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md


### PR DESCRIPTION
Before:
![image](https://github.com/ChainAgnostic/namespaces/assets/1979423/9674ec3b-5762-425a-8387-07635fbfdfb1)

After:
![image](https://github.com/ChainAgnostic/namespaces/assets/1979423/e6f357a8-931e-494e-8e0e-64e1907ba5ee)
