### PR TITLE
Aleo: Add CAIP-2 and CAIP-10 specs

### DIFF
--- a/aleo/README.md
+++ b/aleo/README.md
@@ -1,7 +1,7 @@
 ---
 namespace-identifier: aleo
 title: Aleo Network
-author: Jonathan Gonzalez (@jonandgon)
+author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
 discussions-to: <URL of PR, mailing list, etc>
 status: Draft
 type: Standard

--- a/aleo/README.md
+++ b/aleo/README.md
@@ -1,0 +1,28 @@
+---
+namespace-identifier: aleo
+title: Aleo Network
+author: Jonathan Gonzalez (@jonandgon)
+discussions-to: <URL of PR, mailing list, etc>
+status: Draft
+type: Standard
+created: 2023-09-12
+requires (*optional): <["CAIP-2", "CAIP-10"]>
+---
+
+# Namespace for Aleo Network Blockchains
+
+This document defines the applicability of CAIP schemes to the networks of the Aleo Network blockchain ecosystem.
+
+# Syntax
+
+The `aleo` namespace refers to networks and other objects within the Aleo Network blockchain ecosystem.
+
+# References
+
+- [Aleo Network Documentation][]: Developer docs for the Aleo Network.
+
+[Aleo Network Documentation]: https://developer.aleo.org
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/aleo/README.md
+++ b/aleo/README.md
@@ -15,7 +15,7 @@ This document defines the applicability of CAIP schemes to the networks of the A
 
 # Syntax
 
-The `aleo` namespace refers to networks and other objects within the Aleo Network blockchain ecosystem.
+The `aleo` namespace profiles CAIP scheme and behaviors for referring to networks and other objects within the Aleo Network blockchain ecosystem.
 
 # References
 

--- a/aleo/README.md
+++ b/aleo/README.md
@@ -6,7 +6,7 @@ discussions-to: <URL of PR, mailing list, etc>
 status: Draft
 type: Standard
 created: 2023-09-12
-requires (*optional): <["CAIP-2", "CAIP-10"]>
+requires: ["CAIP-2", "CAIP-10"]
 ---
 
 # Namespace for Aleo Network Blockchains

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -1,7 +1,7 @@
 ---
 namespace-identifier: aleo-caip10
 title: Aleo Network - Namespace Accounts
-author: Jonathan Gonzalez (@jonandgon)
+author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
 discussions-to: <URL of PR, mailing list, etc>
 status: Draft
 type: Standard

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -19,7 +19,7 @@ requires (*optional): <["CAIP-10"]>
 
 # CAIP-10
 
-*For context, see the [CAIP-10][https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md`] specification.*
+*For context, see the [CAIP-10][] specification.*
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the CAIP.-->
 
 ## Rationale

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -6,7 +6,7 @@ discussions-to: <URL of PR, mailing list, etc>
 status: Draft
 type: Standard
 created: 2023-09-12
-requires (*optional): <["CAIP-10"]>
+requires: CAIP-10
 ---
 
 <!--You can leave these HTML comments in your merged CAIP and delete the 

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -43,7 +43,10 @@ A regular expression for validating an Aleo address can be defined as:
 
 ```env
 # Aleo Testnet3
-aleo:testnet3:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
+aleo:3:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
+
+# Aleo Mainnet
+aleo:0:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
 ```
 
 ## Additional Considerations (*OPTIONAL)

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -1,0 +1,68 @@
+---
+namespace-identifier: aleo-caip10
+title: Aleo Network - Namespace Accounts
+author: Jonathan Gonzalez (@jonandgon)
+discussions-to: <URL of PR, mailing list, etc>
+status: Draft
+type: Standard
+created: 2023-09-12
+requires (*optional): <["CAIP-10"]>
+---
+
+<!--You can leave these HTML comments in your merged CAIP and delete the 
+ visible duplicate text guides, they will not appear and may be helpful to 
+ refer to if you edit it again. This is the suggested template for new CAIPs.
+ Note that an CAIP number will be assigned by an editor. When opening a pull
+ request to submit your EIP, please use an abbreviated title in the 
+ filename, `caipX.md`, all lowercase, no `-` between the CAIP and its 
+ number.-->
+
+# CAIP-10
+
+*For context, see the [CAIP-10][https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md`] specification.*
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the CAIP.-->
+
+## Rationale
+<!--A short (~200 word) description of the technical issue being addressed.-->
+An Aleo account address is a unique identifier that allows users to transfer value and record data to one another in transactions.
+
+The account address is comprised of a public key for the account encryption scheme.
+
+## Syntax
+
+Address Format Example
+`aleo1dg722m22fzpz6xjdrvl9tzu5t68zmypj5p74khlqcac0gvednygqxaax0j`
+
+An account address is formatted as a `Bech32` string, comprised of 63 characters. The account address is encoded with an address prefix that reads `aleo1`.
+
+A regular expression for validating an Aleo address can be defined as:
+
+`^aleo1[a-z0-9]{58}$`
+
+## Test Cases
+
+```env
+# Aleo Testnet3
+aleo:testnet3:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
+```
+
+## Additional Considerations (*OPTIONAL)
+
+Account addresses / keys are chain-agnostic.
+
+Mainnet will release sometime at the end of 2023 / beginning of 2024. The API is subject to change.
+
+## References
+<!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->
+- [Aleo Network Documentation][]: Developer docs for the Aleo Network.
+- [Aleo Account Documentation][]: Developer docs for account creation.
+
+[Aleo Network Documentation]: https://developer.aleo.org
+[Aleo Account Documentation]: https://developer.aleo.org/concepts/accounts
+[CAIP-2]: https://chainAgnostic.org/CAIPS/caip-2
+[CAIP-10]: https://chainAgnostic.org/CAIPS/caip-10
+[aleo CAIP-2]: aleo/caip2
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -28,12 +28,13 @@ The namespace `aleo` refers to the Aleo Network Layer 1 blockchain.
 
 To date, Aleo consists of a single network: a testnet network (Testnet3).
 
-An identifier for a Aleo chain consists of the namespace prefix "aleo:"
-followed by the chain id.
+An identifier for a Aleo chain consists of the namespace prefix "aleo:" followed by the chain id.
 
 ## Syntax
 
-The Aleo chain ID is the name of the chain. e.g. `3` for testnet3 or `0` for when mainnet is released. The chain id is a `u16` number ranging from 0 to 65535.
+The Aleo chain ID system maps between a human-readabe string (used to discriminate networks in the paths of [node endpoints][], for example) and an unsigned 16-bit binary integer, known colloquially as an "`u16` number", ranging from 0 to 65535 which is used internally.
+For example, at time or writing, the u16 number `3` maps to `testnet3` and `0` will map to `mainnet` once the latter has been released. 
+The canonical location of the mapping of u16 integers to network name strings is still to be determined by the community, but in the case of conflicts between the community documentation and this document, the former should be taken as canonical. 
 
 ### Backwards Compatibility
 
@@ -73,6 +74,7 @@ The API is subject to change and the example above (particularly other propertie
 - [Aleo Network Documentation][]: Developer docs for the Aleo Network.
 
 [Aleo Network Documentation]: https://developer.aleo.org
+[node endpoints]: https://developer.aleo.org/testnet/getting_started/overview/#query-the-network
 [CAIP-2]: https://chainAgnostic.org/CAIPS/caip-2
 
 ## Copyright

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -36,49 +36,6 @@ followed by the chain id.
 The Aleo chain ID is the name of the chain. e.g. `testnet3` or `mainnet` when mainnet is released. 
 regex: `/^(testnet3|mainnet)$/i`
 
-### Resolution Mechanics
-
-To obtain the genesis block hash, make a JSON-RPC request to the Aleo api.
-
-Request (aleo testnet3):
-
-```curl
-curl --request GET \
-  --url https://vm.aleo.org/api/testnet3/block/0 \
-```
-
-Response (aleo testnet3):
-
-```json
-{
-  "block_hash": "ab1cxu7kq6j8yva9nzq394jt90qnpeexsr0fdnqfdzgqrx4fn7czcyqknclrd",
-  "previous_hash": "ab1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5g436j",
-  "header": {
-  "previous_state_root": "0field",
-    "transactions_root": "2421468861514346193702333205411662486965424378250484763660928941797390483657field",
-    "finalize_root": "2347499756727239097527357730627929185508370696360031054030113664724940109165field",
-    "ratifications_root": "2347499756727239097527357730627929185508370696360031054030113664724940109165field",
-    "coinbase_accumulator_point": "0field",
-    "metadata": {
-      "network": 3,
-      "round": 0,
-      "height": 0,
-      "total_supply_in_microcredits": 1500000000000000,
-      "cumulative_weight": 0,
-      "cumulative_proof_target": 0,
-      "coinbase_target": 4095,
-      "proof_target": 32,
-      "last_coinbase_target": 4095,
-      "last_coinbase_timestamp": 1680307200,
-      "timestamp": 1680307200
-    }
-  },
-  "transactions": [ ... ],
-  "ratifications": [],
-  "signature": "sign1t7lf502e0h23jtvls9lagepv5sfvgpxm7yvzwrfhgpqsyevkwqq7hcxuympx2w6c4pt3nvm929l74q96hx9ed57cyvvrdm7hqlt75qm7rawvssddfv078wthdpqynfu3jh5qeruups7t7vyls3jxccnypxa5z55an3zwd9em29wrjxmpyymwflclchtzhr62hwthyumkge2qgcd950p"
-}
-```
-
 ### Backwards Compatibility
 
 n/a
@@ -90,6 +47,9 @@ This is a manually composed example.
 ```env
 # Aleo Testnet3
 aleo:testnet3
+
+# Aleo mainnet
+aleo:mainnet
 ```
 
 ## Additional Considerations (*OPTIONAL)

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -1,0 +1,107 @@
+---
+namespace-identifier: aleo-caip2
+title: Aleo Network - Namespace Chains
+author: Jonathan Gonzalez (@jonandgon)
+discussions-to: <URL of PR, mailing list, etc>
+status: Draft
+type: Standard
+created: 2023-09-12
+requires (*optional): <["CAIP-2"]>
+replaces (*optional): <CAIP-2>
+---
+
+<!--You can leave these HTML comments in your merged CAIP and delete the 
+ visible duplicate text guides, they will not appear and may be helpful to 
+ refer to if you edit it again. This is the suggested template for new CAIPs.
+ Note that an CAIP number will be assigned by an editor. When opening a pull
+ request to submit your EIP, please use an abbreviated title in the 
+ filename, `caipX.md`, all lowercase, no `-` between the CAIP and its 
+ number.-->
+
+# CAIP-2
+
+*For context, see the [CAIP-2][https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md] specification.*
+
+## Rationale
+
+The namespace `aleo` refers to the Aleo Network Layer 1 blockchain.
+
+Aleo consists of a single network: a testnet network (Testnet3).
+
+An identifier for a Aleo chain consists of the namespace prefix "aleo:"
+followed by the chain id.
+
+## Syntax
+
+The Aleo chain ID is the name of the chain. e.g. `testnet3` or `mainnet` when mainnet is released.
+
+### Resolution Mechanics
+
+To obtain the genesis block hash, make a JSON-RPC request to the Aleo api.
+
+Request (aleo testnet3):
+
+```curl
+curl --request GET \
+  --url https://vm.aleo.org/api/testnet3/block/0 \
+```
+
+Response (aleo testnet3):
+
+```json
+{
+  "block_hash": "ab1cxu7kq6j8yva9nzq394jt90qnpeexsr0fdnqfdzgqrx4fn7czcyqknclrd",
+  "previous_hash": "ab1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5g436j",
+  "header": {
+  "previous_state_root": "0field",
+    "transactions_root": "2421468861514346193702333205411662486965424378250484763660928941797390483657field",
+    "finalize_root": "2347499756727239097527357730627929185508370696360031054030113664724940109165field",
+    "ratifications_root": "2347499756727239097527357730627929185508370696360031054030113664724940109165field",
+    "coinbase_accumulator_point": "0field",
+    "metadata": {
+      "network": 3,
+      "round": 0,
+      "height": 0,
+      "total_supply_in_microcredits": 1500000000000000,
+      "cumulative_weight": 0,
+      "cumulative_proof_target": 0,
+      "coinbase_target": 4095,
+      "proof_target": 32,
+      "last_coinbase_target": 4095,
+      "last_coinbase_timestamp": 1680307200,
+      "timestamp": 1680307200
+    }
+  },
+  "transactions": [ ... ],
+  "ratifications": [],
+  "signature": "sign1t7lf502e0h23jtvls9lagepv5sfvgpxm7yvzwrfhgpqsyevkwqq7hcxuympx2w6c4pt3nvm929l74q96hx9ed57cyvvrdm7hqlt75qm7rawvssddfv078wthdpqynfu3jh5qeruups7t7vyls3jxccnypxa5z55an3zwd9em29wrjxmpyymwflclchtzhr62hwthyumkge2qgcd950p"
+}
+```
+
+### Backwards Compatibility
+
+n/a
+
+## Test Cases
+
+This is a manually composed example.
+
+```env
+# Aleo Testnet3
+aleo:testnet3
+```
+
+## Additional Considerations (*OPTIONAL)
+
+Mainnet will release sometime at the end of 2023 / beginning of 2024. The API is subject to change.
+
+## References
+<!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->
+- [Aleo Network Documentation][]: Developer docs for the Aleo Network.
+
+[Aleo Network Documentation]: https://developer.aleo.org
+[CAIP-2]: https://chainAgnostic.org/CAIPS/caip-2
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -39,6 +39,18 @@ The Aleo chain ID is the name of the chain. e.g. `3` for testnet3 or `0` for whe
 
 n/a
 
+### Resolution Method
+
+To resolve a reference for the Aleo namespace, get the latest block information from the chain you are interested in from an Aleo API node. An example using Javascript:
+
+```env
+fetch('https://api.explorer.aleo.org/v1/testnet3/latest/block')
+  .then(response => response.json())
+  .then(response => console.log(response.header.metadata.network))
+```
+
+will log `3`.
+
 ## Test Cases
 
 This is a manually composed example.

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -33,8 +33,7 @@ followed by the chain id.
 
 ## Syntax
 
-The Aleo chain ID is the name of the chain. e.g. `testnet3` or `mainnet` when mainnet is released. 
-regex: `/^(testnet3|mainnet)$/i`
+The Aleo chain ID is the name of the chain. e.g. `3` for testnet3 or `0` for when mainnet is released. The chain id is a `u16` number ranging from 0 to 65535.
 
 ### Backwards Compatibility
 
@@ -46,15 +45,15 @@ This is a manually composed example.
 
 ```env
 # Aleo Testnet3
-aleo:testnet3
+aleo:3
 
 # Aleo mainnet
-aleo:mainnet
+aleo:0
 ```
 
 ## Additional Considerations (*OPTIONAL)
 
-Mainnet will release sometime at the end of 2023 / beginning of 2024. 
+Mainnet will release sometime Q1 2024. 
 The API is subject to change and the example above (particularly other properties) may become inaccurate over time.
 
 ## References

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -20,7 +20,7 @@ replaces (*optional): <CAIP-2>
 
 # CAIP-2
 
-*For context, see the [CAIP-2][https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md] specification.*
+*For context, see the [CAIP-2][] specification.*
 
 ## Rationale
 

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -33,7 +33,8 @@ followed by the chain id.
 
 ## Syntax
 
-The Aleo chain ID is the name of the chain. e.g. `testnet3` or `mainnet` when mainnet is released.
+The Aleo chain ID is the name of the chain. e.g. `testnet3` or `mainnet` when mainnet is released. 
+regex: `/^(testnet3|mainnet)$/i`
 
 ### Resolution Mechanics
 

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -93,7 +93,8 @@ aleo:testnet3
 
 ## Additional Considerations (*OPTIONAL)
 
-Mainnet will release sometime at the end of 2023 / beginning of 2024. The API is subject to change.
+Mainnet will release sometime at the end of 2023 / beginning of 2024. 
+The API is subject to change and the example above (particularly other properties) may become inaccurate over time.
 
 ## References
 <!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -26,7 +26,7 @@ replaces (*optional): <CAIP-2>
 
 The namespace `aleo` refers to the Aleo Network Layer 1 blockchain.
 
-Aleo consists of a single network: a testnet network (Testnet3).
+To date, Aleo consists of a single network: a testnet network (Testnet3).
 
 An identifier for a Aleo chain consists of the namespace prefix "aleo:"
 followed by the chain id.

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -1,7 +1,7 @@
 ---
 namespace-identifier: aleo-caip2
 title: Aleo Network - Namespace Chains
-author: Jonathan Gonzalez (@jonandgon)
+author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
 discussions-to: <URL of PR, mailing list, etc>
 status: Draft
 type: Standard


### PR DESCRIPTION
This is the start of adding CAIP specs for the [Aleo Network](https://developer.aleo.org/). Aleo is a privacy-focused L1 that uses zero-knowledge proofs. 