### PR TITLE
[Errata arweave/caip122] - explicitly add signatureMeta.t value

### DIFF
--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -71,7 +71,7 @@ Type: ${type}
 Signature: ${signature}
 ```
 
-The signature creation process on Arweave is done through the `arweave-js` library. The message data model is expressed in string format. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`. At time or writing, the only type of signature (and thus the only valid value for `signatureMeta.t`) is `arweaveSign`. 
+The signature creation process on Arweave is done through the `arweave-js` library. The message data model is expressed in string format. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`. At time or writing, the only type of signature (and thus the only valid value for `signatureMeta.t`) is `arweaveSign`, and where no signature type is explicitly set this should be the implicit value. 
 
 ### Signature Verification
 

--- a/arweave/caip122.md
+++ b/arweave/caip122.md
@@ -71,7 +71,7 @@ Type: ${type}
 Signature: ${signature}
 ```
 
-The signature creation process on Arweave is done through the `arweave-js` library. The message data model is expressed in string format. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`.
+The signature creation process on Arweave is done through the `arweave-js` library. The message data model is expressed in string format. This string is signed using the RSA-PSS algorithm through a manual call to the `sign()` method from the `arweave-js` library. The signature is returned as a Uint8Array of bytes which is then Base64Url encoded by calling `arweave.utils.bufferTob64Url()`. At time or writing, the only type of signature (and thus the only valid value for `signatureMeta.t`) is `arweaveSign`. 
 
 ### Signature Verification
 


### PR DESCRIPTION
Nota bene @ropats16 @joshbenaron @danmacdonald @zachferland :
Implementer feedback on CAIP-122 pointed out that to me that profiles need to explicitly NAME signature types so that they can be referenced in each CACAO conforming to that name. We made it [more explicit for future profilers](https://github.com/ChainAgnostic/CAIPs/pull/247/files#diff-c0928c7ab9eb00925c752323139aa16e42a74e5a3720bbab0bf7b4cb78ca0dbdR55-R59) but now we're also going back and inserting one for this CAIP-122 profile.  the name was chosen out of a hat so please "request changes" if you can think of a more precise, descriptive, and/or future-proof one!