### PR TITLE
Casper namespace - Added `discussions-to` header. Fixed authors.

### DIFF
--- a/casper/README.md
+++ b/casper/README.md
@@ -1,7 +1,8 @@
 ---
 namespace-identifier: casper
 title: Casper network
-author: <["FirstName1 LastName1 (@GitHubUsername1)", "David Hernando <david.hernando@make.services>"]>
+author: <["David Hernando <david.hernando@make.services>", "Adrian Wrona <adrian@casper.network>"]>
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/100
 status: Draft
 type: Informational
 created: 2024-01-12

--- a/casper/caip10.md
+++ b/casper/caip10.md
@@ -1,8 +1,8 @@
 ---
 namespace-identifier: casper-caip10
 title: Casper - Addresses
-author: "FirstName1 LastName1 (@GitHubUsername1)", "David Hernando <david.hernando@make.services>"
-discussions-to: <URL of PR, mailing list, etc>
+author: <["David Hernando <david.hernando@make.services>", "Adrian Wrona <adrian@casper.network>"]>
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/100
 status: Draft
 type: Standard
 created: 2024-01-12

--- a/casper/caip2.md
+++ b/casper/caip2.md
@@ -1,7 +1,8 @@
 ---
 namespace-identifier: casper-caip2
 title: Casper Chains
-author: "FirstName1 LastName1 (@GitHubUsername1)", "David Hernando <david.hernando@make.services>"
+author: <["David Hernando <david.hernando@make.services>", "Adrian Wrona <adrian@casper.network>"]>
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/100
 status: Draft
 type: Standard
 created: 2024-01-12


### PR DESCRIPTION
Small PR to add `discussions-to` header and fix authors list.