### PR TITLE
Update and extend tezos-caip2/10/122 + Tezos namespace

### DIFF
--- a/tezos/README.md
+++ b/tezos/README.md
@@ -1,11 +1,11 @@
 ---
 namespace-identifier: tezos
-title: Tezos Ecosystem
-author: Stanly Johnson (@stanly-johnson)
+title: Tezos Namespace
+author: Stanly Johnson (@stanly-johnson), Carlo van Driesten (@jdsika)
 status: Draft
 type: Informational
 created: 2020-12-12
-updated: 2022-03-27
+updated: 2024-02-20
 replaces: CAIP-26
 ---
 
@@ -16,18 +16,33 @@ the Tezos ecosystem.
 
 ## Syntax
 
-The namespace "tezos" refers to the Tezos open-source blockchain platform.
+The namespace "tezos" refers to the Tezos open-source blockchain protocol in general. The main implementation is called [Octez][]. The [Tezos test network infrastructure][] provides an overview of the different chains maintained by the community. The Tezos Mainnet can be determined through the genesis block hash: `BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2`.
+
+### Chain IDs
+
+_For context, see the [CAIP-2][] specification and in particular the `tezos-caip2` profile thereof._
+
+| Network Name | Chain ID                         |
+| ------------ | -------------------------------- |
+| Mainnet      | NetXdQprcVkpaWU                  |
+| Ghostnet     | NetXnHfVqm9iesp                  |
 
 ## References
 
-- [Tezos Address types][]: Important context on the Tezos system of addresses and key representations.
-- [Tezos RPC Interface][]: Important context on communicating with Tezos nodes over RPC.
-- [Implementation](https://gitlab.com/tezos/tezos/blob/e7612c5ffa46570cdcc612f7bcead771edc24283/src/lib_crypto/chain_id.ml)
+- [Tezos Website][] - Official project website.
+- [Octez][] - Main implementation for the Tezos standard.
+- [Octez Documentation][] - How to get started with Tezos.
+- [Tezos Foundation][] - Non-profit organization supporting Tezos ecosystem development.
+- [CAIP-2][] - Blockchain Chain ID Specification.
+- [tzstats.com Tezos Mainnet Genesis Block][] - A Tezos block explorer and the Tezos Mainnet Genesis Block.
 
-[Tezos RPC Interface]: https://tezos.gitlab.io/introduction/howtouse.html#rpc-interface
-[Tezos Address types]: https://tezos.gitlab.io/introduction/howtouse.html#implicit-accounts-and-smart-contracts
-[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
-[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[Tezos Website]: https://tezos.com/
+[Octez]: https://research-development.nomadic-labs.com/announcing-octez.html
+[Octez Documentation]: https://tezos.gitlab.io/
+[Tezos Foundation]: https://tezos.foundation/
+[Tezos test network infrastructure]: https://teztnets.com/
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[tzstats.com Tezos Mainnet Genesis Block]: https://tzstats.com/0
 
 ## Rights
 

--- a/tezos/caip10.md
+++ b/tezos/caip10.md
@@ -1,12 +1,12 @@
 ---
 namespace-identifier: tezos-caip10
-title: Tezos Namespace - Addresses
-author: Qibing Li (@QibingLee)
+title: Tezos Namespace - Account ID Specification
+author: Qibing Li (@QibingLee), Carlo van Driesten (@jdsika)
 discussions-to: https://github.com/ChainAgnostic/namespaces/pull/40
 status: Draft
 type: Standard
 created: 2022-12-06
-updated: 2023-01-17
+updated: 2024-02-20
 requires: ["CAIP-2", "CAIP-10"]
 ---
 
@@ -17,8 +17,8 @@ _For context, see the [CAIP-10][] specification._
 ## Rationale
 
 Tezos supports the use of multiple public-key signature schemes, so the display
-address is prefixed with `tz1` (Ed25519 curve), `tz2` (Secp256k1 curve), or
-`tz3` (P256 curve). After the prefix, the rest of the account address is a
+address is prefixed with `tz1` ([Ed25519][] curve), `tz2` ([Secp256k1][] curve), or
+`tz3` ([NIST P256][] curve). After the prefix, the rest of the account address is a
 [base58][] hash of each key's public key.
 
 ## Syntax
@@ -30,32 +30,45 @@ The syntax of a Tezos address matches the following regular expression (note the
 
 ## Chain IDs
 
-_For context, see the [CAIP-2][] specification or the `tezos-caip2` profile thereof._
+_For context, see the [CAIP-2][] specification and in particular the `tezos-caip2` profile thereof._
 
 | Network Name | Chain ID                         |
 | ------------ | -------------------------------- |
-| Mainnet      | NetXdQprcVkpaWU |
-| Delphinet    | NetXm8tYqnMWky1 |
+| Mainnet      | NetXdQprcVkpaWU                  |
+| Ghostnet     | NetXnHfVqm9iesp                  |
 
 ## Test Cases
 
-```
-# Tezos Mainnet
-tezos:NetXdQprcVkpaWU:tz1MVqWiyfMbSESTaGEPxFjDWdM9zSXy1hcg
+The Tezos namespace, the chain ID and the [Tezos Address Types][] allow the construction of the [CAIP-10][] compliant `Account ID`:
 
-# Tezos DelphiNet (Current active testnet)
-tezos:NetXm8tYqnMWky1:tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB
+```bash
+# Tezos Mainnet
+# Genesis block hash: BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2
+tezos:NetXdQprcVkpaWU:tz1MJx9vhaNRSimcuXPK2rW4fLccQnDAnVKJ
+
+# Tezos Ghostnet (Long-running test network)
+# Genesis block hash: BLockGenesisGenesisGenesisGenesisGenesis1db77eJNeJ9
+tezos:NetXnHfVqm9iesp:tz3btDQsDkqq2G7eBdrrLqetaAfLVw6BnPez
 ```
 
 ## References
 
-- [Tezos Smart Contract](https://opentezos.com/tezos-basics/smart-contracts#general-definition-of-a-tezos-smart-contract): General definition of a Tezos smart contract
-- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
-- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
+- [Tezos Address Types][] - Important context on the Tezos system of addresses and key representations.
+- [Tezos Smart Contract][]: General definition of a Tezos smart contract.
+- [CAIP-2][]: Blockchain ID Specification.
+- [CAIP-10][]: Account ID Specification.
+- [Ed25519][] - Ed25519: high-speed high-security signatures.
+- [Secp256k1][] - Elliptic curve used in Bitcoin's public-key cryptography.
+- [NIST P256][] - One of the most used elliptic curves including native support in some mobile devices.
 
-[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-10.md
-[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[Tezos Address Types]: https://tezos.gitlab.io/introduction/howtouse.html#implicit-accounts-and-smart-contracts
+[Tezos Smart Contract]: https://opentezos.com/tezos-basics/smart-contracts#general-definition-of-a-tezos-smart-contract
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
 [Base58]: https://datatracker.ietf.org/doc/html/draft-msporny-base58-03
+[Ed25519]: https://ed25519.cr.yp.to/
+[Secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
+[NIST P256]: https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
 
 ## Rights
 

--- a/tezos/caip10.md
+++ b/tezos/caip10.md
@@ -1,0 +1,62 @@
+---
+namespace-identifier: tezos-caip10
+title: Tezos Namespace - Addresses
+author: Qibing Li (@QibingLee)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/40
+status: Draft
+type: Standard
+created: 2022-12-06
+updated: 2023-01-17
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+_For context, see the [CAIP-10][] specification._
+
+## Rationale
+
+Tezos supports the use of multiple public-key signature schemes, so the display
+address is prefixed with `tz1` (Ed25519 curve), `tz2` (Secp256k1 curve), or
+`tz3` (P256 curve). After the prefix, the rest of the account address is a
+[base58][] hash of each key's public key.
+
+## Syntax
+
+The syntax of a Tezos address matches the following regular expression (note the
+58-character alphabet):
+
+`(tz1|tz2|tz3) [1-9A-HJ-NP-Za-km-z]{33}`
+
+## Chain IDs
+
+_For context, see the [CAIP-2][] specification or the `tezos-caip2` profile thereof._
+
+| Network Name | Chain ID                         |
+| ------------ | -------------------------------- |
+| Mainnet      | NetXdQprcVkpaWU |
+| Delphinet    | NetXm8tYqnMWky1 |
+
+## Test Cases
+
+```
+# Tezos Mainnet
+tezos:NetXdQprcVkpaWU:tz1MVqWiyfMbSESTaGEPxFjDWdM9zSXy1hcg
+
+# Tezos DelphiNet (Current active testnet)
+tezos:NetXm8tYqnMWky1:tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB
+```
+
+## References
+
+- [Tezos Smart Contract](https://opentezos.com/tezos-basics/smart-contracts#general-definition-of-a-tezos-smart-contract): General definition of a Tezos smart contract
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md): Blockchain ID Specification
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md): Account ID Specification
+
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/8fdb5bfd1bdf15c9daf8aacfbcc423533764dfe9/CAIPs/caip-10.md
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[Base58]: https://datatracker.ietf.org/doc/html/draft-msporny-base58-03
+
+## Rights
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tezos/caip122.md
+++ b/tezos/caip122.md
@@ -1,13 +1,13 @@
 ---
 namespace-identifier: tezos-caip122
-title: Tezos Namespace - SIWx
-author: Qibing Li (@QibingLee)
+title: Tezos Namespace - Sign in With X (SIWx)
+author: Qibing Li (@QibingLee), Carlo van Driesten (@jdsika)
 discussions-to: TBA
 status: Draft
 type: Standard
 created: 2022-12-06
-updated: 2022-12-15
-requires: ["CAIP-122", "CAIP-2", "CAIP-10"]
+updated: 2024-02-20
+requires: ["CAIP-2", "CAIP-10", "CAIP-122"]
 ---
 
 ## CAIP-122
@@ -16,10 +16,7 @@ For context, see the [CAIP-122][] specification.
 
 ## Rationale
 
-Tezos supports three types of keys, `tz1` for Ed25519 keys, `tz2` for Secp256k1
-keys and `tz3` for P256 keys. This specification provides the signing algorithm
-to use, the `type` of the signing algorithm to identify it, and a method for
-signature creation and verification as required by [CAIP-122][].
+Tezos supports three address types with respective key prefixes, `tz1` for [Ed25519][] keys, `tz2` for [Secp256k1][] keys and `tz3` for [NIST P256][] keys specified in [CAIP-10][] and the respective `tezos-caip10` specification. This specification provides the signing algorithm to use, the `type` of the signing algorithm to identify it, and a method for signature creation and verification as required by [CAIP-122][].
 
 ## Specification
 
@@ -45,7 +42,7 @@ over.
 
 We propose the following string format, inspired by [EIP-4361][].
 
-```
+```text
 ${domain} wants you to sign in with your Tezos account:
 ${address}
 
@@ -76,14 +73,21 @@ because there is no solution to recover the public key from `tz1`, `tz2`, OR
 
 ## References
 
-[EIP-4361]: https://eips.ethereum.org/EIPS/eip-4361
-[CAIP-122]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md
+- [CAIP-2][] - Blockchain ID Specification.
+- [CAIP-10][] - Account ID Specification.
+- [CAIP-122][] - Sign in With X (SIWx).
+- [EIP-4361][] - Sign-In with Ethereum.
+- [Ed25519][] - Ed25519: high-speed high-security signatures.
+- [Secp256k1][] - Elliptic curve used in Bitcoin's public-key cryptography.
+- [NIST P256][] - One of the most used elliptic curves including native support in some mobile devices.
 
-- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) - Sign-In with Ethereum
-- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) - Account ID Specification
-- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) - Blockchain ID Specification
-- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md) - Sign in With X Specification
-- [Ed25519](https://ed25519.cr.yp.to/) - Ed25519: high-speed high-security signatures
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
+[CAIP-122]: https://chainagnostic.org/CAIPs/caip-122
+[EIP-4361]: https://eips.ethereum.org/EIPS/eip-4361
+[Ed25519]: https://ed25519.cr.yp.to/
+[Secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
+[NIST P256]: https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
 
 ## Rights
 

--- a/tezos/caip122.md
+++ b/tezos/caip122.md
@@ -1,0 +1,90 @@
+---
+namespace-identifier: tezos-caip122
+title: Tezos Namespace - SIWx
+author: Qibing Li (@QibingLee)
+discussions-to: TBA
+status: Draft
+type: Standard
+created: 2022-12-06
+updated: 2022-12-15
+requires: ["CAIP-122", "CAIP-2", "CAIP-10"]
+---
+
+## CAIP-122
+
+For context, see the [CAIP-122][] specification.
+
+## Rationale
+
+Tezos supports three types of keys, `tz1` for Ed25519 keys, `tz2` for Secp256k1
+keys and `tz3` for P256 keys. This specification provides the signing algorithm
+to use, the `type` of the signing algorithm to identify it, and a method for
+signature creation and verification as required by [CAIP-122][].
+
+## Specification
+
+### Signing Algorithm
+
+In Tezos, Ed25519 (`tz1`) is the most commonly used signing algorithm. Tezos
+uses prefixed base58 hashes of key material and signatures, with distinct
+prefixes to encode the public key, private key and signatures. For Ed25519, the
+prefixes are `edpk`, `edsk` and `edsig`. For Secp256k1, the prefixes are `sppk`,
+`spsk` and `spsig`. For P256, the prefixes are `p2pk`, `p2sk` and `p2sig`.
+
+### Signature Type
+
+We propose using any of the three signature types (`tezos:ed25519`,
+`tezos:secp256k1` and `tezos:p256`) to allow Tezos wallets to sign with `tz1`,
+`tz2` or `tz3` addresses for off-chain authentication purposes.
+
+### Signature Creation
+
+The abstract data model must be converted into a string representation in an
+unambigious format, and then the string converted to a byte array to be signed
+over.
+
+We propose the following string format, inspired by [EIP-4361][].
+
+```
+${domain} wants you to sign in with your Tezos account:
+${address}
+
+${statement}
+
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Nonce: ${nonce}
+Issued At: ${timestamp}
+Expiration Time: ${expiration-time}
+Not Before: ${not-before}
+Request ID: ${request-id}
+Resources:
+- ${resources[0]}
+- ${resources[1]}
+...
+- ${resources[n]}
+```
+
+### Signature Verification
+
+Tezos signatures and public keys are base58 encoded with prefixes. Once these
+have been removed, we can use standard signature verification methods. Note that
+the signature and the signing public key should be sent together to verifiers,
+because there is no solution to recover the public key from `tz1`, `tz2`, OR
+`tz3` signatures.
+
+## References
+
+[EIP-4361]: https://eips.ethereum.org/EIPS/eip-4361
+[CAIP-122]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md
+
+- [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) - Sign-In with Ethereum
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) - Account ID Specification
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) - Blockchain ID Specification
+- [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-122.md) - Sign in With X Specification
+- [Ed25519](https://ed25519.cr.yp.to/) - Ed25519: high-speed high-security signatures
+
+## Rights
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tezos/caip2.md
+++ b/tezos/caip2.md
@@ -1,12 +1,12 @@
 ---
 namespace-identifier: tezos
 title: Blockchain Reference for the Tezos Namespace - Chains
-author: Stanly Johnson (@stanly-johnson)
-discussions-to: ["https://github.com/ChainAgnostic/CAIPs/pull/36", "https://gitlab.com/tezos/tezos/-/issues/1029"]
+author: Stanly Johnson (@stanly-johnson), Carlo van Driesten (@jdsika)
+discussions-to: ["https://github.com/ChainAgnostic/CAIPs/pull/36", "https://gitlab.com/tezos/tezos/-/issues/1029", https://github.com/ChainAgnostic/namespaces/pull/40]
 status: Draft
 type: Standard
 created: 2020-12-12
-updated: 2022-03-27
+updated: 2024-02-20
 requires: CAIP-2
 supersedes: CAIP-26
 ---
@@ -24,13 +24,13 @@ namespace.
 
 ## Syntax
 
-Blockchains in the "tezos" namespace are identified by their chain ID derived deterministically from a short, prefixed Blake-2B hash of their genesis block. 
+Blockchains in the "tezos" namespace are identified by their chain ID derived deterministically from a short, prefixed Blake-2B hash of their genesis block.
 
 ### Reference Definition
 
-The method for calculating the hash of a given chain's genesis block (for use as a CAIP-2 chain ID) is as follows:
+The method for calculating the hash of a given chain's genesis block (for use as a CAIP-2 chain ID) is as follows from the [Base58 Function Reference Implementation][]:
 
-```
+```ocaml
 tezosB58CheckEncode('Net',
   firstFourBytes(
     blake2b(msg = tezosB58CheckDecode('B', genesisBlockHash),
@@ -43,26 +43,44 @@ Not applicable
 
 ## Test Cases
 
-This is a list of manually composed examples
+This is a list of manually composed examples. See [Tezos test network infrastructure][] for available public chains. You can use the [Tezos RPC Interface][] to compute the chain id from a block hash as follows:
 
+```text
+# Tezos Ghostnet (Long-running test network)
+> ./octez-client compute chain id from block hash BLockGenesisGenesisGenesisGenesisGenesis1db77eJNeJ9
+NetXnHfVqm9iesp
 ```
+
+```text
 # Tezos Mainnet
+# Genesis block hash: BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2
 tezos:NetXdQprcVkpaWU
 
-# Tezos DelphiNet (Current active testnet)
-tezos:NetXm8tYqnMWky1
+# Tezos Ghostnet (Long-running test network)
+# Genesis block hash: BLockGenesisGenesisGenesisGenesisGenesis1db77eJNeJ9
+tezos:NetXnHfVqm9iesp
 ```
 
 ## References
 
-- [Tezos Address types][]: Important context on the Tezos system of addresses and key representations.
-- [Tezos RPC Interface][]: Important context on communicating with Tezos nodes over RPC.
-- [Implementation](https://gitlab.com/tezos/tezos/blob/e7612c5ffa46570cdcc612f7bcead771edc24283/src/lib_crypto/chain_id.ml)
+- [Tezos Address Types][] - Important context on the Tezos system of addresses and key representations further specified in [CAIP-10].
+- [Tezos RPC Interface][] - Important context on communicating with Tezos nodes over RPC.
+- [Tezos Block Explorer][] - Can be used to investigate block hashs on Mainnet and Ghostnet.
+- [Chain_ID Reference Implementation][] - Octez implementation for Tezos.
+- [Octez][] - Main implementation for the Tezos standard.
+- [Base58 Function Reference Implementation][] - Octez reference implementation.
+- [Taquito Typescript Library][] - Available Base58 functions in Typescript for Tezos.
 
-[Tezos RPC Interface]: https://tezos.gitlab.io/introduction/howtouse.html#rpc-interface
-[Tezos Address types]: https://tezos.gitlab.io/introduction/howtouse.html#implicit-accounts-and-smart-contracts
 [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[Tezos Address Types]: https://tezos.gitlab.io/introduction/howtouse.html#implicit-accounts-and-smart-contracts
+[Tezos RPC Interface]: https://tezos.gitlab.io/introduction/howtouse.html#rpc-interface
+[Tezos Block Explorer]: https://tzstats.com/
+[Chain_ID Reference Implementation]: https://gitlab.com/tezos/tezos/-/blob/5bb8fd589cc8777f44c795b71acf3e0a5dcac06f/src/lib_crypto/chain_id.ml
+[Octez]: https://research-development.nomadic-labs.com/announcing-octez.html
+[Base58 Function Reference Implementation]: https://gitlab.com/tezos/tezos/-/blob/5bb8fd589cc8777f44c795b71acf3e0a5dcac06f/src/lib_crypto/blake2B.ml
+[Taquito Typescript Library]: https://tezostaquito.io/typedoc/functions/_taquito_utils.b58decode#b58decode
 [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[Tezos test network infrastructure]: https://teztnets.com/
 
 ## Rights
 

--- a/tezos/caip2.md
+++ b/tezos/caip2.md
@@ -1,6 +1,6 @@
 ---
-namespace-identifier: tezos
-title: Blockchain Reference for the Tezos Namespace - Chains
+namespace-identifier: tezos-caip2
+title: Tezos Namespace - Blockchain ID Specification
 author: Stanly Johnson (@stanly-johnson), Carlo van Driesten (@jdsika)
 discussions-to: ["https://github.com/ChainAgnostic/CAIPs/pull/36", "https://gitlab.com/tezos/tezos/-/issues/1029", https://github.com/ChainAgnostic/namespaces/pull/40]
 status: Draft
@@ -18,13 +18,11 @@ supersedes: CAIP-26
 
 ## Rationale
 
-In CAIP-2 a general blockchain identification scheme is defined. This is the
-implementation of CAIP-2 for the chain identification system of the Tezos
-namespace.
+In CAIP-2 a general blockchain identification scheme is defined. This is the implementation of CAIP-2 for the chain identification system of the Tezos namespace.
 
 ## Syntax
 
-Blockchains in the "tezos" namespace are identified by their chain ID derived deterministically from a short, prefixed Blake-2B hash of their genesis block.
+Blockchains in the "tezos" namespace are identified by their chain ID derived deterministically from a short, prefixed Blake-2B hash of their `genesis-block-hash`.
 
 ### Reference Definition
 
@@ -39,19 +37,21 @@ tezosB58CheckEncode('Net',
 
 ### Backwards Compatibility
 
-Not applicable
+Not applicable.
 
 ## Test Cases
 
 This is a list of manually composed examples. See [Tezos test network infrastructure][] for available public chains. You can use the [Tezos RPC Interface][] to compute the chain id from a block hash as follows:
 
-```text
+```bash
 # Tezos Ghostnet (Long-running test network)
 > ./octez-client compute chain id from block hash BLockGenesisGenesisGenesisGenesisGenesis1db77eJNeJ9
 NetXnHfVqm9iesp
 ```
 
-```text
+Now the CAIP-2 compliant chain ID can be constructed using the Tezos namespace as prefix:
+
+```bash
 # Tezos Mainnet
 # Genesis block hash: BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2
 tezos:NetXdQprcVkpaWU
@@ -63,23 +63,23 @@ tezos:NetXnHfVqm9iesp
 
 ## References
 
-- [Tezos Address Types][] - Important context on the Tezos system of addresses and key representations further specified in [CAIP-10].
+- [Tezos Address Types][] - Important context on the Tezos system of addresses and key representations further specified in the `tezos-caip10` derived from [CAIP-10].
 - [Tezos RPC Interface][] - Important context on communicating with Tezos nodes over RPC.
 - [Tezos Block Explorer][] - Can be used to investigate block hashs on Mainnet and Ghostnet.
-- [Chain_ID Reference Implementation][] - Octez implementation for Tezos.
+- [Chain ID Reference Implementation][] - Octez implementation for Tezos.
 - [Octez][] - Main implementation for the Tezos standard.
 - [Base58 Function Reference Implementation][] - Octez reference implementation.
 - [Taquito Typescript Library][] - Available Base58 functions in Typescript for Tezos.
 
-[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 [Tezos Address Types]: https://tezos.gitlab.io/introduction/howtouse.html#implicit-accounts-and-smart-contracts
 [Tezos RPC Interface]: https://tezos.gitlab.io/introduction/howtouse.html#rpc-interface
 [Tezos Block Explorer]: https://tzstats.com/
-[Chain_ID Reference Implementation]: https://gitlab.com/tezos/tezos/-/blob/5bb8fd589cc8777f44c795b71acf3e0a5dcac06f/src/lib_crypto/chain_id.ml
+[Chain ID Reference Implementation]: https://gitlab.com/tezos/tezos/-/blob/5bb8fd589cc8777f44c795b71acf3e0a5dcac06f/src/lib_crypto/chain_id.ml
 [Octez]: https://research-development.nomadic-labs.com/announcing-octez.html
 [Base58 Function Reference Implementation]: https://gitlab.com/tezos/tezos/-/blob/5bb8fd589cc8777f44c795b71acf3e0a5dcac06f/src/lib_crypto/blake2B.ml
 [Taquito Typescript Library]: https://tezostaquito.io/typedoc/functions/_taquito_utils.b58decode#b58decode
-[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
 [Tezos test network infrastructure]: https://teztnets.com/
 
 ## Rights


### PR DESCRIPTION
@bumblefudge I can finally make some time to finalize this work which has been started in https://github.com/ChainAgnostic/namespaces/pull/40 .

I think you can review the following documents and decide if this qualifies for a status "final":
* readme
* tezos-caip-2
* tezos-caip-10

I am not sure if the required specifications need to list the respective namespace derivative or the original specification (or both)?
> requires: ["CAIP-2", "CAIP-10"]

I have addressed this comment here:

> Could we update CAIP-2 (and the chainIDs in CAIP-10 while we're here) with a Limanet and a Ghostnet example? If you could add, as I did in the CAIP-2 the genesis block hash, it helps people test their own computation of the chainID string for private chains or future testnets...

I will continue with your comments regarding the tezos-caip122