### PR TITLE
feat: merge CAIP69 into CAIP10 for specifying EOA wallets

### DIFF
--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -97,6 +97,9 @@ We should have users sign a message to prove they have an EOA (Greg to fill out 
 [CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
 [CAIP-21]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-21.md
 [CAIP-22]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md
+[CAIP-122]: https://chainagnostic.org/CAIPs/caip-122
+[ERC-4361]: https://eips.ethereum.org/EIPS/eip-4361
+[EIP-1193]: https://eips.ethereum.org/EIPS/eip-1193
 [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
 [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
 [ERC-20]: https://eips.ethereum.org/EIPS/eip-20

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -23,7 +23,12 @@ specified for the unfamiliar.
 
 ### Special case of EOA
 
-In order to enable decentralized applications to specify EOAs as an address, we propose using chainID 0. This would signify that it can live on multiple networks. In absence of this, addresses will be assigned to only one chain using CAIP-10 chainID syntax, an EOA would be required to be assigned multiple times for each chain. Specifying 0 as chainID for EOA, further enables EOAs to be designated as an EOA once, and be treated as an EOA on every applicable chain
+To express Ethereum account without reference to any specific [EIP-155][] chain ID, CAIP-10 identifiers can use the special `chainId` segment `0`.
+
+In the Ethereum account system, "externally owned accounts" (i.e. "offchain" wallets) are controlled by user agents and not by on-chain entities (i.e. deployed or deployable smart contract code). 
+The special chainId `0` SHOULD only be used for accounts that can be used in off-chain contexts, i.e. without the use of an Ethereum node.
+
+Note that a given address cannot be assumed to work on all current and future networks with an [EIP-155][] `chainId`, which may express or derive addresses differently for a given private key; a user account expressed with `chainId` segment of 0 is assumed to control the same account on `chainId` 1 and most ethereum chains, but MAY control a different account or additional accounts on networks that extend the account or addressing model of Ethereum, assume different key or hash derivations, etc.
 
 ## Syntax
 

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -29,9 +29,9 @@ In order to enable decentralized applications to specify EOAs as an address, we 
 
 Ethereum addresses were, historically, case-insensitive and normalized to use
 all-lowercase letters (`abcdef`) like most hexadecimal numeric types.  With the
-ratification of [EIP55][], however, a particular normalization of lowercase- and
+ratification of [EIP-55][], however, a particular normalization of lowercase- and
 uppercase- `abcdefABCDEF` characters was invented as an efficient form of
-checksum. See [EIP55][] for specification.
+checksum. See [EIP-55][] for specification.
 
 The chain ID will be used to represent blockchain except special case of 0 as chainID to represent EOA.
 
@@ -80,11 +80,11 @@ We should have users sign a message to prove they have an EOA (Greg to fill out 
 
 ## References
 
-- [EIP155][]: Ethereum Improvement Proposal specifying generation and validation of ChainIDs
+- [EIP-155][]: Ethereum Improvement Proposal specifying generation and validation of ChainIDs
 - [ethereum-lists/chains][]: An open registry for eip155 network operators to claim a
       unique chainID and self-publish RPC/node information for them.
-- [ERC20][]: Basic [aka Fungible] Token Standard
-- [ERC721][]: Non-Fungible Token Standard
+- [ERC-20][]: Basic [aka Fungible] Token Standard
+- [ERC-721][]: Non-Fungible Token Standard
 
 [Chainid.network]: https://github.com/ethereum-lists/chains
 [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
@@ -92,10 +92,10 @@ We should have users sign a message to prove they have an EOA (Greg to fill out 
 [CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
 [CAIP-21]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-21.md
 [CAIP-22]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md
-[EIP155]: https://eips.ethereum.org/EIPS/eip-155
-[EIP55]: https://eips.ethereum.org/EIPS/eip-55
-[ERC20]: https://eips.ethereum.org/EIPS/eip-20
-[ERC721]: https://eips.ethereum.org/EIPS/eip-721
+[EIP-155]: https://eips.ethereum.org/EIPS/eip-155
+[EIP-55]: https://eips.ethereum.org/EIPS/eip-55
+[ERC-20]: https://eips.ethereum.org/EIPS/eip-20
+[ERC-721]: https://eips.ethereum.org/EIPS/eip-721
 
 
 ## Rights

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -81,7 +81,7 @@ eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B
 
 ## Security Considerations
 
-We should have users sign a message to prove they have an EOA (Greg to fill out more completely)
+As the Ethereum namespace evolved, user-agents that connect to dapps through an [EIP-1193][] interface started to accrue "off-chain" use-cases such as authenticating control of an onchain account with an "off-chain" signature (i.e. a transaction signed by the wallet and verified by a dapp or website without either party submitting it to a node or running any on-chain functions). It is RECOMMENDED that wallets using the chainId of `0` be authenticated in a standardized and secure manner which produces verifiable receipts of the authenticaiton event, such as that documented in [ERC-4361][] and extended by [CAIP-122][].
 
 ## References
 

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -41,7 +41,7 @@ The `chain_id` string will be ammended as follows:
 chain_id:    namespace + ":" + network_id + ":" + reference
 network_id:    [0-9]{1,1}
 namespace:   [-a-z0-9]{3,8}
-reference:   [-_a-zA-Z0-9]{1,32}
+reference:   0x[-_a-fA-F0-9]{1,32}
 ```
 
 ### Backwards Compatibility

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -79,7 +79,7 @@ eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B
 
 ```
 
-## Security Concerns
+## Security Considerations
 
 We should have users sign a message to prove they have an EOA (Greg to fill out more completely)
 

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -21,6 +21,10 @@ While Ethereum "accounts" were the unstated norm in the definition of
 [CAIP-10][], there are still some particularities of the syntax that should be
 specified for the unfamiliar.  
 
+### Special case of EOA
+
+In order to enable decentralized applications to specify EOAs as an address, we propose using chainID 0. This would signify that it can live on multiple networks. In absence of this, addresses will be assigned to only one chain using CAIP-10 chainID syntax, an EOA would be required to be assigned multiple times for each chain. Specifying 0 as chainID for EOA, further enables EOAs to be designated as an EOA once, and be treated as an EOA on every applicable chain
+
 ## Syntax
 
 Ethereum addresses were, historically, case-insensitive and normalized to use
@@ -28,6 +32,17 @@ all-lowercase letters (`abcdef`) like most hexadecimal numeric types.  With the
 ratification of [EIP55][], however, a particular normalization of lowercase- and
 uppercase- `abcdefABCDEF` characters was invented as an efficient form of
 checksum. See [EIP55][] for specification.
+
+The chain ID will be used to represent blockchain except special case of 0 as chainID to represent EOA.
+
+The `chain_id` string will be ammended as follows:
+
+```
+chain_id:    namespace + ":" + eoa_flag + ":" + reference
+eoa_flag:    [0-9]{1,1}
+namespace:   [-a-z0-9]{3,8}
+reference:   [-_a-zA-Z0-9]{1,32}
+```
 
 ### Backwards Compatibility
 
@@ -42,6 +57,9 @@ accounts in this manner.
 ## Test Cases
 
 ```
+# EOA
+eip155:0:0x839395e20bbB182fa440d08F850E6c7A8f6F0780
+
 # Ethereum mainnet (valid/checksummed)
 eip155:1:0x22227A31dd842196A246d8f3b775998560eAa61d
 
@@ -55,6 +73,10 @@ eip155:137:0x0495766cD136138Fc492Dd499B8DC87A92D6685b
 eip155:137:0x0495766CD136138FC492DD499B8DC87A92D6685B
 
 ```
+
+## Security Concerns
+
+We should have users sign a message to prove they have an EOA (Greg to fill out more completely)
 
 ## References
 

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -46,7 +46,7 @@ The `chain_id` string will be ammended as follows:
 chain_id:    namespace + ":" + network_id + ":" + reference
 network_id:    [0-9]{1,19}
 namespace:   [-a-z0-9]{3,8}
-reference:   0x[-_a-fA-F0-9]{1,32}
+reference:   0x[a-fA-F0-9]{1,32}
 ```
 
 ### Backwards Compatibility

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -39,7 +39,7 @@ The `chain_id` string will be ammended as follows:
 
 ```
 chain_id:    namespace + ":" + network_id + ":" + reference
-network_id:    [0-9]{1,1}
+network_id:    [0-9]{1,19}
 namespace:   [-a-z0-9]{3,8}
 reference:   0x[-_a-fA-F0-9]{1,32}
 ```

--- a/eip155/caip10.md
+++ b/eip155/caip10.md
@@ -38,8 +38,8 @@ The chain ID will be used to represent blockchain except special case of 0 as ch
 The `chain_id` string will be ammended as follows:
 
 ```
-chain_id:    namespace + ":" + eoa_flag + ":" + reference
-eoa_flag:    [0-9]{1,1}
+chain_id:    namespace + ":" + network_id + ":" + reference
+network_id:    [0-9]{1,1}
 namespace:   [-a-z0-9]{3,8}
 reference:   [-_a-zA-Z0-9]{1,32}
 ```


### PR DESCRIPTION
The goal of this PR is to empower CAIP 10 to specify EOA across EVM Chains with chainID of 0. 

We raised a PR for this earlier in CAIP repo https://github.com/ChainAgnostic/CAIPs/pull/268 and based on review comments/suggestions, we are raising this PR. 
