### PR TITLE
Mina CAIPS 2 - updating links to docs

### DIFF
--- a/mina/caip2.md
+++ b/mina/caip2.md
@@ -35,7 +35,7 @@ The type of network may be:
 - devnet, indicating a stable copy of the network used for developer testing.
 - testnet, indicating a less stable copy of the network where new features can be deployed and tested. 
 
-The names chosen above are taken from the signature schema's for each blockchain and current network identifiers can be found in the documentation [here](https://docs2-git-major-upgrade-minadocs.vercel.app/node-operators)
+The names chosen above are taken from the signature schema's for each blockchain and current network identifiers can be found in the documentation [here](https://docs.minaprotocol.com/node-operators)
 
 ## Syntax
 


### PR DESCRIPTION
The mina mainnet upgrade is scheduled for June 4th. As such the docs have been updated and released. This PR updates a link to the mina documentation as it has now been updated and released to show the network identifiers.