### PR TITLE
Add Aleo Mainnet specs, update Aleo Testnet specs

### DIFF
--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: aleo-caip10
 title: Aleo Network - Namespace Accounts
 author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
-discussions-to: <URL of PR, mailing list, etc>
+discussions-to: https://discord.com/invite/puzzlearcade
 status: Draft
 type: Standard
 created: 2023-09-12
@@ -42,8 +42,8 @@ A regular expression for validating an Aleo address can be defined as:
 ## Test Cases
 
 ```env
-# Aleo Testnet3
-aleo:3:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
+# Aleo Testnet
+aleo:1:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
 
 # Aleo Mainnet
 aleo:0:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
@@ -51,9 +51,7 @@ aleo:0:aleo1ml2xr6fawppd6uaf8gn95uy2fpqqg8gk74k0lu8na7uvayk64v8qu8hw5u
 
 ## Additional Considerations (*OPTIONAL)
 
-Account addresses / keys are chain-agnostic.
-
-Mainnet will release sometime at the end of 2023 / beginning of 2024. The API is subject to change.
+Account addresses / keys are chain-agnostic. Signatures, however, are NOT chain agnostic. 
 
 ## References
 <!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->

--- a/aleo/caip10.md
+++ b/aleo/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: aleo-caip10
 title: Aleo Network - Namespace Accounts
 author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
-discussions-to: https://discord.com/invite/puzzlearcade
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/129
 status: Draft
 type: Standard
 created: 2023-09-12

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: aleo-caip2
 title: Aleo Network - Namespace Chains
 author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
-discussions-to: https://discord.com/invite/puzzlearcade
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/129
 status: Draft
 type: Standard
 created: 2023-09-12
@@ -25,8 +25,6 @@ replaces (*optional): <CAIP-2>
 ## Rationale
 
 The namespace `aleo` refers to the Aleo Network Layer 1 blockchain.
-
-To date, Aleo consists of a single network: a testnet network (Testnet).
 
 An identifier for a Aleo chain consists of the namespace prefix "aleo:" followed by the chain id.
 

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: aleo-caip2
 title: Aleo Network - Namespace Chains
 author: Jonathan Gonzalez (@jonandgon, jonathan@puzzle.online)
-discussions-to: <URL of PR, mailing list, etc>
+discussions-to: https://discord.com/invite/puzzlearcade
 status: Draft
 type: Standard
 created: 2023-09-12
@@ -26,14 +26,14 @@ replaces (*optional): <CAIP-2>
 
 The namespace `aleo` refers to the Aleo Network Layer 1 blockchain.
 
-To date, Aleo consists of a single network: a testnet network (Testnet3).
+To date, Aleo consists of a single network: a testnet network (Testnet).
 
 An identifier for a Aleo chain consists of the namespace prefix "aleo:" followed by the chain id.
 
 ## Syntax
 
 The Aleo chain ID system maps between a human-readabe string (used to discriminate networks in the paths of [node endpoints][], for example) and an unsigned 16-bit binary integer, known colloquially as an "`u16` number", ranging from 0 to 65535 which is used internally.
-For example, at time or writing, the u16 number `3` maps to `testnet3` and `0` will map to `mainnet` once the latter has been released. 
+For example, at time or writing, the u16 number `1` maps to `testnet` and `0` will map to `mainnet` once the latter has been released. 
 The canonical location of the mapping of u16 integers to network name strings is still to be determined by the community, but in the case of conflicts between the community documentation and this document, the former should be taken as canonical. 
 
 ### Backwards Compatibility
@@ -45,29 +45,28 @@ n/a
 To resolve a reference for the Aleo namespace, get the latest block information from the chain you are interested in from an Aleo API node. An example using Javascript:
 
 ```env
-fetch('https://api.explorer.aleo.org/v1/testnet3/latest/block')
+fetch('https://api.explorer.provable.com/v1/mainnet/latest/block')
   .then(response => response.json())
   .then(response => console.log(response.header.metadata.network))
 ```
 
-will log `3`.
+will log `0`.
 
 ## Test Cases
 
 This is a manually composed example.
 
 ```env
-# Aleo Testnet3
-aleo:3
+# Aleo Testnet
+aleo:1
 
-# Aleo mainnet
+# Aleo Mainnet
 aleo:0
 ```
 
 ## Additional Considerations (*OPTIONAL)
 
-Mainnet will release sometime Q1 2024. 
-The API is subject to change and the example above (particularly other properties) may become inaccurate over time.
+Testnet3 has been deprecated and shut down in favor of Testnet.
 
 ## References
 <!--Links to external resources that help understanding the CAIP better. This can e.g. be links to existing implementations.-->

--- a/aleo/caip2.md
+++ b/aleo/caip2.md
@@ -33,7 +33,7 @@ An identifier for a Aleo chain consists of the namespace prefix "aleo:" followed
 ## Syntax
 
 The Aleo chain ID system maps between a human-readabe string (used to discriminate networks in the paths of [node endpoints][], for example) and an unsigned 16-bit binary integer, known colloquially as an "`u16` number", ranging from 0 to 65535 which is used internally.
-For example, at time or writing, the u16 number `1` maps to `testnet` and `0` will map to `mainnet` once the latter has been released. 
+For example, at time or writing, the u16 number `1` maps to `testnet` and `0` maps to `mainnet`. 
 The canonical location of the mapping of u16 integers to network name strings is still to be determined by the community, but in the case of conflicts between the community documentation and this document, the former should be taken as canonical. 
 
 ### Backwards Compatibility


### PR DESCRIPTION
[Aleo Mainnet has launched!](https://aleo.org/post/announcing-aleo-mainnet/)

To help the ecosystem adopt the WalletConnect/CAIP standard, we are updating the specs for the two active Aleo chains.