### PR TITLE
Fix page deployment (bump `actions/upload-pages-artifact` to `v3`)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Recently, the [`Upload artifact` step](https://github.com/ChainAgnostic/namespaces/actions/runs/13202072151) failed because the `actions/upload-pages-artifact@v1` action is using a deprecated version of `actions/upload-artifact@v3`.

This PR bumps `actions/upload-pages-artifact` to `v3`, which [uses `actions/upload-artifact@v4`](https://github.com/actions/upload-pages-artifact/blob/v3/action.yml#L77).