### PR TITLE
update syntax and example after 5792 syntax changes

### DIFF
--- a/eip155/caip25.md
+++ b/eip155/caip25.md
@@ -34,7 +34,10 @@ see the [eip155/caip211.md](./caip211.md) profile for further guidance on using 
 No namespace-wide or network-specific session properties have yet been proposed for standardization.
 When crafting such properties for contextual/in-network usage, it is recommended to align one's semantics and syntax (including case-sensitive style guides for property names!) with the [EIP-6963] wallet provider interface (which extends the [EIP-1193] interface) for common properties across architectures, making sure to avoid any collisions.
 
-Similarly, wherever possible, session properties should align closely with information passed as JSON objects by `wallet_` RPC methods, like capabilities or permissions. For example, the capability objects keyed to hexidecimal [EIP-155] `chainId`s defined as the expected return content of the `wallet_getCapabilities` method in [EIP-5792] should also be valid keyed the same way in `sessionProperties.capabilities`.
+Similarly, wherever possible, session properties should align closely with information passed as JSON objects by `wallet_` RPC methods, like capabilities or permissions. 
+For example, the capability objects specified in [EIP-5792] get passed via the `wallet_getCapabilities` RPC method inside of partition objects keyed to the hexadecimal chainId when chain-specific, and inside of an object keyed `0x00` (following the chainId 0 convention; see the [`eip155`/caip2 profile](caip2)) when universal to the `eip155` namespace.
+Should an application request and a wallet choose to pre-declare at time of connection, both parties can put such objects in the appropriately-keyed `scopedProperties` partition for chain-specific capabilities and in the `sessionProperties` (unpartitioned) for `eip155`-wide capabilities.
+See the example below, equivalent to the illustrative examples in [EIP-5792].
 
 ## Examples
 
@@ -52,7 +55,7 @@ Similarly, wherever possible, session properties should align closely with infor
         "methods": ["eth_sendTransaction", "eth_signTransaction", "eth_sign", "get_balance", "personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"]
       },
-      "eip155:10": {
+      "eip155:8453": {
         "methods": ["get_balance"],
         "notifications": ["accountsChanged", "chainChanged"]
       },
@@ -65,16 +68,34 @@ Similarly, wherever possible, session properties should align closely with infor
       }
     },
     "optionalScopes":{
-      "eip155:42161": {
+      "eip155:84532": {
         "methods": ["eth_sendTransaction", "eth_signTransaction", "get_balance", "personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"]
     },
     "sessionProperties": {
       "expiry": "2022-12-24T17:07:31+00:00",
       "caip154": {
-          "supported":"true"
+        "supported":"true"
+      },
+      "flow-control": {
+        "supported": "true"
       }
-    }         
+    },
+    "scopedProperties": {
+      "8453": {
+        "paymasterService": {
+          "supported": true
+        },
+        "sessionKeys": {
+          "supported": true
+        }
+      },
+      "84532": {
+        "auxiliaryFunds": {
+          "supported": true
+        }
+      }
+    }
   }
 }
 ```
@@ -94,15 +115,10 @@ Similarly, wherever possible, session properties should align closely with infor
         "notifications": ["accountsChanged", "chainChanged"],
         "accounts": ["eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb", "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"]
       },
-      "eip155:10": {
-        "methods": ["get_balance"],
-        "notifications": ["accountsChanged", "chainChanged"],
-        "accounts:" []
-      },
-      "eip155:42161": {
+      "eip155:83532": {
         "methods": ["personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"],
-        "accounts":["eip155:42161:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
+        "accounts":["eip155:83532:0x0910e12C68d02B561a34569E1367c9AAb42bd810"]
       },
       "wallet": {
         "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_getCapabilities"],
@@ -113,23 +129,20 @@ Similarly, wherever possible, session properties should align closely with infor
       }
     },      
     "sessionProperties": {
-      "capabilities": {
-          "0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb": {
-            "0x31": {
-              "paymasterService": {
-                 "supported": true
-               },
-               "sessionKeys": {
-                  "supported": true
-               }
-            },
-            "0x3432313631": {
-              "sessionKeys": {
-                "supported": false
-              }              
-            }
-          }
-       }   
+      "expiry": "2022-12-24T17:07:31+00:00",
+      "caip154": {
+        "supported":"true"
+      },
+      "flow-control": {
+        "supported": "true"
+      }
+    },
+    "scopedProperties": {
+      "84532": {
+        "auxiliaryFunds": {
+          "supported": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Updated the 5792 `wallet_getCapabilities` equivalence spec language and examples following the introduction of the ["chainId 0" convention](https://github.com/eth-infinitism/EIPs/commit/5f3a1cdd91b88e9bb6d4b018dfa940bbe9f94961#diff-7a494500c37dc4b57613207d62874322198a4ced215f4a0457a0af908bb6364eR280) in Alex Forshtat's PR on 5792 [here](https://github.com/ethereum/EIPs/pull/8826)