### PR TITLE
Add quai namespace and CAIP-2 spec

### DIFF
--- a/quai/README.md
+++ b/quai/README.md
@@ -21,7 +21,7 @@ This namespace ensures that cross-chain tools such as WalletConnect, DID methods
 
 Quai protocol upgrades and standards are driven by the Quai Foundation in coordination with the Quai developer community. Improvement proposals are documented via QIPs (Quai Improvement Proposals), with reference implementations and discussion led through the official GitHub repositories and Discord. Final decisions for protocol-level changes are currently stewarded by core contributors, with an aim toward more decentralized governance in future roadmap stages.
 
-All RPC compatibility, chain metadata, and transaction standards are maintained openly at [docs.qu.ai](https://docs.qu.ai) and the [QIPs github repository](https://github.com/quai-network/qips). Developers are encouraged to participate in network design and contribute implementations via the quais.js SDK and go-quai node software repositories.
+All RPC compatibility, chain metadata, and transaction standards are maintained openly at [docs.qu.ai][Quai Docs] and the [QIPs github repository][go-quia Github]. Developers are encouraged to participate in network design and contribute implementations via the quais.js SDK and go-quai node software repositories.
 
 ## References
 

--- a/quai/README.md
+++ b/quai/README.md
@@ -1,0 +1,47 @@
+---
+namespace-identifier: quai
+title: Quai Namespace
+author: ["Jonathan Downing (@jdowning100)", "Dr. K (@mechanikalk)"]
+status: Draft
+type: Informational
+created: 2025-06-18
+---
+
+# Namespace for Quai Network
+
+Quai is a decentralized, merge-mined, EVM-compatible Layer 1 network of blockchains that leverages a next-generation Proof-of-Work consensus mechanism called Proof-of-Entropy-Minima to eliminate block contention and provide lightning fast finality. Unlike traditional multi-chain systems, Quai uses a single global chain ID (9) for all shards and routes transactions based on address location, not per-chain logic, in which every address deterministically maps to a shard via its first byte. It supports protobuf-encoded transactions rather than RLP-encoded, setting it apart from standard Ethereum-based networks.
+
+## Rationale
+
+Quai’s unique architectural model necessitates a distinct namespace for proper identification and interoperability. While it shares EVM compatibility at the level of contract execution, its divergence in transaction encoding (protobuf), shard-based address space, and shared global chain ID differentiate it from traditional Ethereum forks. Currently, only one shard is active in Quai, so integration is relatively simple.
+
+This namespace ensures that cross-chain tools such as WalletConnect, DID methods, and asset resolvers can interpret Quai’s model accurately — especially given the single-chain ID model combined with a sharded execution environment.
+
+## Governance
+
+Quai protocol upgrades and standards are driven by the Quai Foundation in coordination with the Quai developer community. Improvement proposals are documented via QIPs (Quai Improvement Proposals), with reference implementations and discussion led through the official GitHub repositories and Discord. Final decisions for protocol-level changes are currently stewarded by core contributors, with an aim toward more decentralized governance in future roadmap stages.
+
+All RPC compatibility, chain metadata, and transaction standards are maintained openly at [docs.qu.ai](https://docs.qu.ai) and the [QIPs github repository](https://github.com/quai-network/qips). Developers are encouraged to participate in network design and contribute implementations via the quais.js SDK and go-quai node software repositories.
+
+## References
+
+- [Quai Docs][] - Official Quai documentation including address sharding, quais.js SDK and Proof-of-Entropy-Minima (PoEM) reference
+- [Quai Docs: JSON-RPC][] - JSON-RPC Reference
+- [go-quai Github][] - Source code repository for the node protocol implementation
+- [Quai Improvement Proposals Github][] - Repository for QIPs and protocol design, including address sharding, Qi energy-based flatcoin controller design, and dynamic network expansion
+- [PoEM: A Better Proof-of-Work Fork Choice Rule][] - PoEM security proof, incentive design, and selfish mining analysis
+- [Quaiscan][] - Quai block explorer, currently running on shard 0, also known as cyprus-1
+- [Pelagus Wallet][] - Browser extension-based wallet that allows users to hold QUAI and interact with Quai mainnet and testnet dApps
+- [quais.js][] - SDK for deploying contracts and building dApps that interact with Quai
+
+[Quai Docs]: https://docs.qu.ai
+[Quai Docs: JSON-RPC]: https://docs.qu.ai/build/playground/overview#json-rpc-overview
+[go-quai Github]: https://github.com/dominant-strategies/go-quai
+[Quai Improvement Proposals Github]: https://github.com/quai-network/qips
+[PoEM: A Better Proof-of-Work Fork Choice Rule]: https://eprint.iacr.org/2024/200
+[Quaiscan]: https://quaiscan.io
+[Pelagus Wallet]: https://pelgauswallet.io
+[quais.js]: https://github.com/dominant-strategies/quais.js
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/quai/caip10.md
+++ b/quai/caip10.md
@@ -1,0 +1,201 @@
+---
+namespace-identifier: quai-caip10
+title: Quai Namespace - Addresses
+author: ["Jonathan Downing (@jdowning100)", "Dr. K (@mechanikalk)"]
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/145
+status: Draft
+type: Standard
+created: 2025-07-22
+requires: ["CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+Quai Network implements a unique sharded address space where every address deterministically routes to a specific shard based on its first byte prefix. Unlike traditional multi-chain systems that require separate chain IDs, Quai uses a single global chain ID (9 for mainnet, 15000 for testnet) across all shards, with address-based routing determining transaction execution location. The first byte encodes both the shard location (region and zone) and the ledger type (Quai account-based or Qi UTXO-based), making addresses self-describing for routing purposes.
+
+## Rationale
+
+Quai's address space requires specialized CAIP-10 handling due to its unique sharded architecture. Traditional blockchain addresses are simply identifiers within a single state space, but Quai addresses encode routing information that determines which shard processes transactions. The first byte of every Quai address contains:
+
+- **Bits 0-3**: Region number (0-15)
+- **Bits 4-7**: Zone number within region (0-15) 
+- **Bit 8**: Ledger identifier (0=Quai accounts, 1=Qi UTXO)
+
+This creates a deterministic address space where `0x00...` addresses route to region-0/zone-0 (cyprus-1), `0x01...` to region-0/zone-1, etc. Currently only shard 0 (cyprus-1) is active on mainnet, so all addresses begin with `0x00`. As network demand grows, additional shards will activate with their corresponding address prefixes. This specification enables proper interpretation of Quai addresses for cross-chain tools, wallets, and asset registries while maintaining compatibility with EVM tooling through checksummed hex encoding.
+
+## Semantics
+
+- **Namespace**: `quai`
+- **Chain ID**: References a specific Quai network environment (9 for mainnet, 15000 for testnet)
+- **Address**: A 20-byte hex-encoded address with EIP-55 checksumming, where the first byte determines shard routing
+- **Address Prefix**: The first byte encodes shard location and ledger type according to QIP-2
+- **Ledger Types**: Quai (account-based, bit 8=0) or Qi (UTXO-based, bit 8=1)
+- **Shard Routing**: Determined by address prefix, not chain ID
+- **Location Encoding**: `(region << 4) | zone` for bits 0-7, plus ledger bit
+
+## Syntax
+
+Quai CAIP-10 addresses follow the format:
+
+```
+quai:<chain_id>:<checksummed_address>
+```
+
+Where:
+- `<chain_id>` is `9` (mainnet) or `15000` (testnet)
+- `<checksummed_address>` is a 40-character hex string (20 bytes) with EIP-55 checksumming
+
+**Regular Expression**:
+```
+^quai:(9|15000):0x[a-fA-F0-9]{40}$
+```
+
+**Address Format**:
+```
+0x[PB][LB][34 hex chars]
+```
+Where:
+- `PB` = Prefix byte encoding shard location `(region << 4) | zone`
+- `LB` = Ledger byte (bit 0/first bit indicates ledger: 0=Quai, 1=Qi)
+- Remaining 18 bytes = Standard address data
+
+**Ledger Detection**:
+- Third hex character `0-7` → Quai ledger (account-based)
+- Third hex character `8-F` → Qi ledger (UTXO-based)
+
+**Prefix Byte Calculation**:
+```
+prefix_byte = (region << 4) | zone
+```
+
+**Valid Examples**:
+- `quai:9:0x00841c4349dbC3CD16098ef0aF2780BA0F7f5C02` (mainnet, cyprus-1 shard)
+- `quai:15000:0x004d2Ee5f59c0A7Df5C54d6C9d5a4f3e3b8E1d2F` (testnet, cyprus-1 shard)
+
+### Resolution Mechanics
+
+To resolve and validate a Quai CAIP-10 address:
+
+1. **Parse the chain reference** to determine network (9=mainnet, 15000=testnet)
+2. **Extract the address prefix** (first byte) to determine shard routing
+3. **Validate EIP-55 checksum** using standard Ethereum checksumming
+4. **Route to appropriate RPC endpoint** based on shard location
+
+**Shard Resolution Example**:
+```javascript
+// Address: 0x00841c4349dbC3CD16098ef0aF2780BA0F7f5C02
+const firstByte = 0x00;
+const region = (firstByte & 0xF0) >> 4;  // 0
+const zone = firstByte & 0x0F;           // 0
+const isQi = (secondByte & 0x80) > 0;    // false (Quai ledger)
+// Routes to: cyprus-1 (region-0, zone-0)
+```
+
+**RPC Validation**:
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "quai_getBalance",
+  "params": ["0x00841c4349dbC3CD16098ef0aF2780BA0F7f5C02", "latest"],
+  "id": 1
+}
+```
+
+**Response**:
+```json
+{
+  "jsonrpc": "2.0", 
+  "result": "0x1b1ae4d6e2ef500000",
+  "id": 1
+}
+```
+
+**Shard-to-Port Mapping**:
+
+When running a local Quai node, each shard operates on a specific port. The address prefix determines which shard (and thus which port) to use:
+
+| Shard      | HTTP RPC Port | Address Prefix | Status |
+|------------|---------------|----------------|---------|
+| `zone-0-0` (cyprus-1) | 9200 | `0x00`, `0x01` | Active |
+| `zone-0-1` (cyprus-2) | 9201 | `0x10`, `0x11` | Inactive |
+| `zone-1-0` (paxos-1)  | 9220 | `0x20`, `0x21` | Inactive |
+| `zone-1-1` (paxos-2)  | 9221 | `0x30`, `0x31` | Inactive |
+| ... | ... | ... | Future expansion |
+
+**Note**: When using quais.js and/or Pelagus wallet with the mainnet RPC, developers and users are abstracted away from the shard-port mapping. If developers run their own node, the shard-port mapping may be a useful reference.
+
+### Backwards Compatibility
+
+Quai addresses maintain full backwards compatibility with Ethereum address formats and tooling:
+
+- **EIP-55 Checksumming**: All Quai addresses use standard Ethereum checksumming
+- **20-byte Format**: Identical to Ethereum address length and structure
+- **Hex Encoding**: Standard 0x-prefixed hex representation
+- **EVM Compatibility**: Addresses work directly with existing Ethereum tooling
+
+##### Note: If a transaction is sent from a Quai address to a Qi address, it will be interpreted as a Quai->Qi conversion. It is therefore highly recommended to check the recipient address before sending a transaction! If a transaction is sent to a Quai address on a different shard, and that shard is not active, the transaction will fail. 
+
+**Legacy Considerations**:
+- Pre-mainnet testnets may have used different address formats - these are deprecated
+- Early documentation may reference different shard numbering - current spec follows QIP-2
+- Address validation should always check current network state for active shards
+
+## Test Cases
+
+### Mainnet Examples (quai:9)
+
+| Address Type | CAIP-10 Address | Shard | Ledger | Notes |
+|--------------|-----------------|-------|-----------|-------|
+| Cyprus-1 Quai | `quai:9:0x000DEAdbeEFCafE0000000000000000000000000` | region-0, zone-0 | Quai | Active shard |
+| Cyprus-1 Qi | `quai:9:0x008fb5C7919B14a1Cd9c2e5f8D3e4B2a7f6c9D0e` | region-0, zone-0 | Qi | UTXO ledger |
+| Future Cyprus-2 | `quai:9:0x014c3e5f1B2A4D6F8e0C9a7b5D3F1e4C2a0b8d6f` | region-0, zone-1 | Quai | Inactive |
+| Future Paxos-1 | `quai:9:0x102a4D6f8e0c9A7b5d3f1e4C2a0b8d6f1C3e5f1b` | region-1, zone-0 | Quai | Inactive |
+
+### Testnet Examples (quai:15000)
+
+| Address Type | CAIP-10 Address | Shard | Ledger | Notes |
+|--------------|-----------------|-------|-----------|-------|
+| Testnet Cyprus-1 | `quai:15000:0x004d2EE5F59c0a7dF5C54D6C9D5a4F3E3B8e1d2f` | region-0, zone-0 | Quai | Orchard testnet |
+| Testnet Qi | `quai:15000:0x00B2f4C6e8a0D2F4E6a8b0D2F4C6e8A0B2F4c6E8` | region-0, zone-0 | Qi | UTXO testnet |
+
+### Invalid Examples
+
+| Invalid Address | Issue | Correct Format |
+|-----------------|-------|----------------|
+| `quai:1:0x00...` | Wrong chain ID | `quai:9:0x00...` |
+| `quai:9:0x00841c...` | Truncated address | Must be 40 hex chars |
+| `quai:9:0x00841C...` | Wrong checksum | Use EIP-55 checksum |
+| `ethereum:1:0x00...` | Wrong namespace | Use `quai` namespace |
+
+## Additional Considerations
+
+**Shard Expansion**: As Quai network grows, new shards will activate with corresponding address prefixes. Address validation should check current network state for active shard ranges.
+
+**Cross-shard Transactions**: Future QIPs may define cross-shard transaction formats that could affect address interpretation and routing.
+
+**Dynamic Expansion**: QIP-2 defines a deterministic shard expansion schedule. CAIP-10 implementations should be prepared for new address prefixes as the network scales.
+
+**Ledger Interoperability**: Conversion between Quai (account) and Qi (UTXO) ledgers may require special address handling in future protocol versions.
+
+## References
+
+- [CAIP-10][] - Account ID specification for blockchain agnostic account addressing
+- [QIP-2][] - Quai Improvement Proposal defining sharded ledger and address space
+- [EIP-55][] - Mixed-case checksum address encoding standard
+- [Quai Docs][] - Official documentation including address sharding and network details
+- [go-quai][] - Reference implementation of Quai protocol with address handling
+- [quais.js][] - JavaScript SDK for Quai development with address utilities
+- [Quaiscan][] - Block explorer showing address format examples
+
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[QIP-2]: https://github.com/quai-network/qips/blob/master/qip-0002.md
+[EIP-55]: https://eips.ethereum.org/EIPS/eip-55
+[Quai Docs]: https://docs.qu.ai
+[go-quai]: https://github.com/dominant-strategies/go-quai
+[quais.js]: https://github.com/dominant-strategies/quais.js
+[Quaiscan]: https://quaiscan.io
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/quai/caip2.md
+++ b/quai/caip2.md
@@ -1,0 +1,126 @@
+---
+namespace-identifier: quai-caip2
+title: Quai Namespace - Chains
+author: ["Jonathan Downing (@jdowning100)", "Dr. K (@mechanikalk)"]
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/145
+status: Draft
+type: Standard
+created: 2025-06-18
+requires: ["CAIP-2"]
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Rationale
+Quai is a merge-mined, EVM-compatible, horizontally scalable Layer 1 blockchain that leverages a novel Proof-of-Work consensus mechanism (PoEM) and address-based sharding for throughput scaling. Unlike traditional multi-chain ecosystems, Quai maintains a **single global chain ID** (`9`) across all shards, relying on address prefixing to determine shard routing.
+
+This CAIP-2 profile defines the valid chain identifiers in the `quai` namespace, including testnet and future devnet/mainnet configurations.
+
+The `quai` namespace requires a distinct CAIP-2 specification to:
+
+- Encode unique blockchain references for use in WalletConnect, DID methods, and asset registries.
+- Support the shared global chain ID (EIP-155: 9) model.
+- Identify and distinguish Quai networks (testnet, mainnet) without needing different chain IDs for shards.
+- Enable forward compatibility with Quai's expanding shard topology.
+
+This approach ensures backward-compatible interop with Ethereum tooling while preserving Quai’s unique scalability model.
+
+## Semantics
+
+- **Namespace**: `quai`
+- **Reference**: A short numeric identifier matching the `chainId` used by EVM-compatible clients (e.g. `9` for mainnet, `15000` for Orchard testnet, etc).
+- **Address Routing**: All mainnet chains use the same global chain ID (9), but routing and execution are determined by the address prefix (see QIP-2).
+- **Sharding Model**: The shard is not encoded in the chain reference but inferred from the address itself.
+
+## Syntax
+
+A valid `quai` CAIP-2 blockchain ID must match the pattern:
+- `quai:9` — Quai Mainnet
+- `quai:15000` — Quai Testnet (Orchard)
+
+Quai does not use separate chain IDs per shard — instead, each account is routed to a shard based on its address prefix (see QIP-2). The reference is not the name of a shard or zone. Instead, it refers to a **logical environment** with its own genesis block (e.g., Quai Orchard Testnet vs Quai Mainnet). Separate chain IDs are used for mainnet (9) and Orchard testnet (15000). Thus, `<reference>` uniquely identifies the logical Quai network.
+
+These two logical environments can also be treated as "chains" in the EVM namespaces, i.e., they can be addressed from EVM contexts unaware of sharding as [eip155][] references. For example:
+- `eip155:9` - Quai Mainnet
+- `eip155:15000` - Quai Testnet (Orchard)
+
+### Resolution Mechanics
+
+To resolve a chain identifier like `quai:15000`, a client should:
+
+1. **Identify the network environment**: 
+   - `quai:9` → Quai Mainnet
+   - `quai:15000` → Quai Testnet (Orchard)
+
+2. **Use the correct chain ID in transactions**:
+   - Mainnet: `9`
+   - Testnet: `15000`
+
+3. **Connect to the appropriate RPC endpoint**:
+   - Mainnet: `https://rpc.quai.network/cyprus1` (currently routes to cyprus-1)
+   - Testnet: `https://orchard.rpc.quai.network/cyprus1` (currently routes to cyprus-1)
+
+**Current State**: With only one active shard (cyprus-1), the chain ID is sufficient to determine the RPC endpoint. **Future State**: As the network expands and additional shards activate, clients will need address-based shard routing (see [CAIP-10 profile](./caip10.md) for shard resolution mechanics).
+
+Sample request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "quai_chainId",
+  "params": [],
+  "id": 1
+}
+```
+
+Sample response (mainnet):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": "0x9",
+  "id": 1
+}
+```
+
+
+### Backwards Compatibility
+
+There are no legacy references or alternate namespace versions at this time. All prior Quai environments use the single chain ID `9` and follow the sharded address space logic described in QIP-2.
+
+## Test Cases
+
+| Blockchain   | CAIP-2 ID    | Chain ID | Notes              |
+| ------------ | ------------ | -------- | ------------------ |
+| Quai Mainnet | `quai:9`     | 9        | Production network |
+| Quai Testnet | `quai:15000` | 15000    | "Orchard" testnet  |
+
+
+## References
+
+- [CAIP-2][]
+- [Quai Docs][] - Official Quai documentation including address sharding, quais.js SDK and Proof-of-Entropy-Minima (PoEM) reference
+- [Quai Docs: JSON-RPC][] - JSON-RPC Reference
+- [go-quai Github][] - Source code repository for the node protocol implementation
+- [Quai Improvement Proposals Github][] - Repository for QIPs and protocol design, including address sharding, Qi energy-based flatcoin controller design, and dynamic network expansion
+- [PoEM: A Better Proof-of-Work Fork Choice Rule][] - PoEM security proof, incentive design, and selfish mining analysis
+- [Quaiscan][] - Quai block explorer, currently running on shard 0, also known as cyprus-1
+- [Pelagus Wallet][] - Browser extension-based wallet that allows users to hold QUAI and interact with Quai mainnet and testnet dApps
+- [quais.js][] - SDK for deploying contracts and building dApps that interact with Quai
+
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[Quai Docs]: https://docs.qu.ai
+[Quai Docs: JSON-RPC]: https://docs.qu.ai/build/playground/overview#json-rpc-overview
+[go-quai Github]: https://github.com/dominant-strategies/go-quai
+[Quai Improvement Proposals Github]: https://github.com/quai-network/qips
+[PoEM: A Better Proof-of-Work Fork Choice Rule]: https://eprint.iacr.org/2024/200
+[Quaiscan]: https://quaiscan.io
+[Pelagus Wallet]: https://pelgauswallet.io
+[quais.js]: https://github.com/dominant-strategies/quais.js
+[eip155]: https://github.com/ChainAgnostic/namespaces/blob/main/eip155/caip2.md
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Quai is a decentralized, merge-mined, EVM-compatible Layer 1 network of blockchains that leverages a Proof-of-Work consensus mechanism called Proof-of-Entropy-Minima to eliminate block contention and provide fast finality. 

Unlike traditional multi-chain systems, Quai uses a single global chain ID (9) for all shards and routes transactions based on address location, not per-chain logic, in which every address deterministically maps to a shard via its first byte. It supports protobuf-encoded transactions rather than RLP-encoded, setting it apart from standard Ethereum-based networks.

Quai’s unique architectural model necessitates a distinct namespace for proper identification and interoperability. While it shares EVM compatibility, its divergence in transaction encoding (protobuf), shard-based address space, and shared global chain ID differentiate it from traditional Ethereum forks. Currently, only one shard is active in Quai, so integration is relatively simple.

This namespace ensures that cross-chain tools such as WalletConnect, DID methods, and asset resolvers can interpret Quai’s model accurately — especially given the single-chain ID model combined with a sharded execution environment.