### PR TITLE
Add `tron` namespace and CAIP-2 specification

### DIFF
--- a/tron/README.md
+++ b/tron/README.md
@@ -19,8 +19,8 @@ The namespace "tron" refers to the TRON blockchain and its testnets.
 
 ## References
 
-- [TRON]: TRON Website
-- [API]: TRON API documentation
+- [TRON Website][TRON]
+- [TRON API documentation][API]
 
 ## Copyright
 

--- a/tron/README.md
+++ b/tron/README.md
@@ -1,0 +1,31 @@
+---
+namespace-identifier: tron
+title: TRON Ecosystem
+author: Daniel Rocha (@danroc)
+status: Draft
+type: Informational
+created: 2025-07-15
+requires:
+  - CAIP-2
+---
+
+# Namespace for TRON chains
+
+This document describes the syntax and structure of the [TRON] namespace.
+
+## Syntax
+
+The namespace "tron" refers to the TRON blockchain and its testnets.
+
+## References
+
+- [TRON]: TRON Website
+- [API]: TRON API documentation
+
+## Copyright
+
+Copyright and related rights waived via [CC0].
+
+[TRON]: https://tron.network/
+[API]: https://developers.tron.network/reference/
+[CC0]: https://creativecommons.org/publicdomain/zero/1.0/

--- a/tron/caip2.md
+++ b/tron/caip2.md
@@ -22,8 +22,8 @@ They are derived from the genesis block hash, as specified in [TIP-474].
 
 A [CAIP-2] chain ID for a TRON network uses the `tron` namespace, and the reference portion is the decimal representation of the value returned by the [`eth_chainId`] RPC method.
 
-In TRON, the RPC’s `eth_chainId` response is defined as the last four bytes of the genesis block hash.
-As a 32-bit value, it ranges from `0x00000000` through `0xFFFFFFFF`.
+In TRON, the RPC’s `eth_chainId` response is defined as the last four bytes of the longer native Tron genesis block hash (see [TIP-474]).
+As a 32-bit value, this shorter, EVM-compatible form ranges from `0x00000000` through `0xFFFFFFFF`.
 
 A full TRON CAIP-2 chain ID has the form:
 

--- a/tron/caip2.md
+++ b/tron/caip2.md
@@ -1,0 +1,99 @@
+---
+namespace-identifier: tron-caip2
+title: TRON Namespace – Chains
+author: Daniel Rocha (@danroc)
+status: Draft
+type: Standard
+created: 2025-07-15
+requires:
+  - CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2] specification.*
+
+## Rationale
+
+In the TRON ecosystem, chain IDs uniquely identify each network. They are
+derived from the genesis block hash, as specified in [TIP-474].
+
+## Syntax
+
+A [CAIP-2] chain ID for a TRON network uses the `tron` namespace, and the
+reference portion is the decimal representation of the value returned by the
+[`eth_chainId`] RPC method.
+
+In TRON, the RPC’s `eth_chainId` response is defined as the last four bytes of
+the genesis block hash. As a 32-bit value, it ranges from `0x00000000` through
+`0xFFFFFFFF`.
+
+A full TRON CAIP-2 chain ID has the form:
+
+```text
+tron:<decimal-chain-id>
+```
+
+## Resolution Mechanics
+
+To obtain the chain ID, send an `eth_chainId` JSON-RPC request to a TRON node:
+
+```json5
+// Request
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "eth_chainId",
+  "params": []
+}
+
+// Response
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": "0x2b6653dc"
+}
+```
+
+The `result` field is a hexadecimal string. Convert it to a base-10 integer to
+obtain the CAIP-2 reference:
+
+```text
+0x2b6653dc → 728126428
+```
+
+Thus, the Mainnet CAIP-2 chain ID becomes:
+
+```text
+tron:728126428
+```
+
+## Test Cases
+
+Here are some common TRON networks and their CAIP-2 chain IDs:
+
+```text
+# TRON Mainnet
+tron:728126428
+
+# TRON Testnet – Shasta
+tron:2494104990
+
+# TRON Testnet – Nile
+tron:3448148188
+```
+
+## References
+
+- [CAIP-2]: CAIP-2 Specification
+- [TIP-474]: TRON Improvement Proposal for chain-ID generation
+- [`eth_chainId`]: TRON JSON-RPC method documentation
+
+## Copyright
+
+All rights waived via [CC0].
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[TIP-474]: https://github.com/tronprotocol/tips/blob/master/tip-474.md
+[`eth_chainId`]: https://developers.tron.network/reference/eth_chainid
+[CC0]: https://creativecommons.org/publicdomain/zero/1.0/

--- a/tron/caip2.md
+++ b/tron/caip2.md
@@ -15,18 +15,15 @@ requires:
 
 ## Rationale
 
-In the TRON ecosystem, chain IDs uniquely identify each network. They are
-derived from the genesis block hash, as specified in [TIP-474].
+In the TRON ecosystem, chain IDs uniquely identify each network.
+They are derived from the genesis block hash, as specified in [TIP-474].
 
 ## Syntax
 
-A [CAIP-2] chain ID for a TRON network uses the `tron` namespace, and the
-reference portion is the decimal representation of the value returned by the
-[`eth_chainId`] RPC method.
+A [CAIP-2] chain ID for a TRON network uses the `tron` namespace, and the reference portion is the decimal representation of the value returned by the [`eth_chainId`] RPC method.
 
-In TRON, the RPC’s `eth_chainId` response is defined as the last four bytes of
-the genesis block hash. As a 32-bit value, it ranges from `0x00000000` through
-`0xFFFFFFFF`.
+In TRON, the RPC’s `eth_chainId` response is defined as the last four bytes of the genesis block hash.
+As a 32-bit value, it ranges from `0x00000000` through `0xFFFFFFFF`.
 
 A full TRON CAIP-2 chain ID has the form:
 
@@ -55,8 +52,7 @@ To obtain the chain ID, send an `eth_chainId` JSON-RPC request to a TRON node:
 }
 ```
 
-The `result` field is a hexadecimal string. Convert it to a base-10 integer to
-obtain the CAIP-2 reference:
+The `result` field is a hexadecimal string. Convert it to a base-10 integer to obtain the CAIP-2 reference:
 
 ```text
 0x2b6653dc → 728126428


### PR DESCRIPTION
This PR adds the `tron` namespace and its CAIP-2 specification.

Rendered files:
- [README](https://github.com/danroc/namespaces/blob/add-tron-ns/tron/README.md)
- [CAIP-2](https://github.com/danroc/namespaces/blob/add-tron-ns/tron/caip2.md)