### PR TITLE
Add Hive namespace with CAIP-2 and CAIP-10 profiles

### DIFF
--- a/hive/README.md
+++ b/hive/README.md
@@ -2,7 +2,7 @@
 namespace-identifier: hive
 title: Hive
 author: ["@feruzm"]
-discussions-to: 
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/174
 status: Draft
 type: Informational
 created: 2026-02-25

--- a/hive/README.md
+++ b/hive/README.md
@@ -22,7 +22,7 @@ Registering the `hive` namespace enables:
 - Standard CAIP-2 chain identifiers for Hive networks
 - Use of CAIP-10 account identifiers for Hive account names
 - Interoperability with multichain wallets and tooling
-- Deterministic identification of Hive mainnet and testnet
+- Deterministic identification of Hive networks (mainnet, mirrornet)
 
 Hive networks expose a protocol-defined `chain_id` used in transaction signing to prevent cross-network replay. This makes Hive suitable for deterministic CAIP-2 identification.
 

--- a/hive/README.md
+++ b/hive/README.md
@@ -1,0 +1,42 @@
+---
+namespace-identifier: hive
+title: Hive
+author: ["@feruzm"]
+discussions-to: 
+status: Draft
+type: Informational
+created: 2026-02-25
+requires: ["CAIP-2"]
+---
+
+# Namespace for Hive
+
+Hive is a delegated-proof-of-stake (DPoS) blockchain focused on social applications, digital publishing, and fast fee-less transactions. It uses account-based identity with human-readable account names.
+
+This document defines the `hive` namespace as a Chain Agnostic Namespace (CAN) to allow standardized identification of Hive networks across multichain tooling using CAIP specifications.
+
+## Rationale
+
+Registering the `hive` namespace enables:
+
+- Standard CAIP-2 chain identifiers for Hive networks
+- Use of CAIP-10 account identifiers for Hive account names
+- Interoperability with multichain wallets and tooling
+- Deterministic identification of Hive mainnet and testnet
+
+Hive networks expose a protocol-defined `chain_id` used in transaction signing to prevent cross-network replay. This makes Hive suitable for deterministic CAIP-2 identification.
+
+## Governance
+
+Hive operates using a Delegated Proof of Stake (DPoS) consensus model. Network upgrades and parameter changes are coordinated by elected block producers ("witnesses") and stakeholders through on-chain governance mechanisms.
+
+## References
+
+- Hive homepage: https://hive.io/
+- Hive developer portal: https://developers.hive.io/
+- Hive configuration values (includes chain_id):  
+  https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+
+## Copyright
+
+Copyright and related rights waived via CC0 1.0.

--- a/hive/caip10.md
+++ b/hive/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: hive-caip10
 title: Hive Namespace - CAIP-10 Account Identifiers
 author: ["@feruzm"]
-discussions-to: 
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/174
 status: Draft
 type: Standard
 created: 2026-02-25

--- a/hive/caip10.md
+++ b/hive/caip10.md
@@ -43,82 +43,102 @@ Where:
 
 Hive account names MUST:
 
-- Be lowercase
-- Be between 3 and 16 characters
-- Contain only:
-  - `a-z`
-  - `0-9`
-  - hyphen (`-`)
-- Not start or end with a hyphen
-- Not contain consecutive hyphens
+- Be between 3 and 16 characters in total length
+- Start with a lowercase letter (`a-z`)
+- Contain only lowercase letters (`a-z`), digits (`0-9`), hyphens (`-`), and dots (`.`)
+- Not start or end with a hyphen or dot
+- Not contain consecutive hyphens or dots
+- If dot-separated, each segment must be at least 3 characters and start with a letter
 
 Regex:
-`[a-z0-9]([a-z0-9-]{1,14}[a-z0-9])?`
 
-Examples
-Hive Mainnet
+```
+^(?=.{3,16}$)[a-z]([0-9a-z]|[0-9a-z\-](?=[0-9a-z])){2,}([\.](?=[a-z][0-9a-z\-][0-9a-z\-])[a-z]([0-9a-z]|[0-9a-z\-](?=[0-9a-z])){1,}){0,}$
+```
 
-`hive:beeab0de000000000000000000000000:ecency`
-`hive:beeab0de000000000000000000000000:good-karma`
-
-Hive Testnet
-
-`hive:4200000000000000000000000000000:testuser`
-
-Resolution
+### Resolution
 
 To validate a Hive CAIP-10 identifier:
 
-Parse the namespace (hive)
-
-Validate the CAIP-2 reference according to the Hive CAIP-2 profile
-
-Validate the account name against Hive naming rules
-
-Query a Hive RPC endpoint to confirm account existence
+1. Parse the namespace (`hive`).
+2. Validate the CAIP-2 reference according to the Hive CAIP-2 profile.
+3. Validate the account name against Hive naming rules.
+4. Query a Hive RPC endpoint to confirm account existence.
 
 Account existence may be verified via:
 
-`condenser_api.get_accounts`
+- `condenser_api.get_accounts`
+- `database_api.find_accounts`
 
-`database_api.find_accounts`
+#### Example Request
 
-Security Considerations
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "condenser_api.get_accounts",
+  "params": [["ecency"]],
+  "id": 1
+}
+```
 
-Hive account names are human-readable and may be subject to phishing using visually similar names.
+## Examples
+
+### Hive Mainnet
+
+```
+hive:beeab0de000000000000000000000000:ecency
+hive:beeab0de000000000000000000000000:good-karma
+hive:beeab0de000000000000000000000000:hive.fund
+hive:beeab0de000000000000000000000000:v4vapp.dhf
+```
+
+### Hive Mirrornet
+
+```
+hive:42000000000000000000000000000000:testuser
+```
+
+## Security Considerations
+
+Hive account names are human-readable and may be subject to phishing using visually similar names (e.g., `ecency` vs `ecency-fake`).
 
 Applications SHOULD:
 
-Validate account existence before processing transactions
-
-Display full CAIP-10 identifiers when clarity is required
-
-Not assume account ownership without authority verification
+- Validate account existence before processing transactions
+- Display full CAIP-10 identifiers when clarity is required
+- Not assume account ownership without authority verification
 
 Because Hive supports multiple authorities (owner, active, posting), CAIP-10 identifiers represent accounts, not individual keys.
 
-Test Cases
+## Test Cases
 
 Valid:
 
-`hive:beeab0de000000000000000000000000:ecency`
-`hive:beeab0de000000000000000000000000:username`
-`hive:4200000000000000000000000000000:test-account`
+```
+hive:beeab0de000000000000000000000000:ecency
+hive:beeab0de000000000000000000000000:good-karma
+hive:beeab0de000000000000000000000000:hive.fund
+hive:beeab0de000000000000000000000000:gtg
+hive:42000000000000000000000000000000:test-account
+```
 
 Invalid:
 
-`hive:beeab0de000000000000000000000000:UpperCase`
-`hive:beeab0de000000000000000000000000:ab`
-`hive:beeab0de000000000000000000000000:-invalid`
+```
+hive:beeab0de000000000000000000000000:UpperCase
+hive:beeab0de000000000000000000000000:ab
+hive:beeab0de000000000000000000000000:-invalid
+hive:beeab0de000000000000000000000000:3digits
+hive:beeab0de000000000000000000000000:has..double
+```
 
-References
+## References
 
-Hive configuration and account rules:
-https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+- Hive configuration and account rules:
+  https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+- CAIP-10 specification:
+  https://chainagnostic.org/CAIPs/caip-10
 
-CAIP-10 specification:
-https://chainagnostic.org/CAIPs/caip-10
-
-Copyright
+## Copyright
 
 Copyright and related rights waived via CC0 1.0.

--- a/hive/caip10.md
+++ b/hive/caip10.md
@@ -1,0 +1,124 @@
+---
+namespace-identifier: hive-caip10
+title: Hive Namespace - CAIP-10 Account Identifiers
+author: ["@feruzm"]
+discussions-to: 
+status: Draft
+type: Standard
+created: 2026-02-25
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+For context, see the CAIP-10 specification:
+https://chainagnostic.org/CAIPs/caip-10
+
+## Rationale
+
+Hive uses account-based identity with human-readable account names rather than hexadecimal address formats.
+
+Each Hive account name:
+
+- Is globally unique within a Hive network
+- Is used directly in transaction operations
+- Is validated at the protocol level
+- Is constrained by naming rules enforced by consensus
+
+Because Hive accounts are stable identifiers and tied to a specific chain via `chain_id`, they are suitable for CAIP-10 account identifiers.
+
+## Specification
+
+A Hive CAIP-10 account identifier MUST follow:
+
+`hive:<reference>:<account>`
+
+Where:
+
+- `hive` is the namespace
+- `<reference>` is defined by the Hive CAIP-2 profile
+- `<account>` is a valid Hive account name
+
+### Account Format
+
+Hive account names MUST:
+
+- Be lowercase
+- Be between 3 and 16 characters
+- Contain only:
+  - `a-z`
+  - `0-9`
+  - hyphen (`-`)
+- Not start or end with a hyphen
+- Not contain consecutive hyphens
+
+Regex:
+`[a-z0-9]([a-z0-9-]{1,14}[a-z0-9])?`
+
+Examples
+Hive Mainnet
+
+`hive:beeab0de000000000000000000000000:ecency`
+`hive:beeab0de000000000000000000000000:good-karma`
+
+Hive Testnet
+
+`hive:4200000000000000000000000000000:testuser`
+
+Resolution
+
+To validate a Hive CAIP-10 identifier:
+
+Parse the namespace (hive)
+
+Validate the CAIP-2 reference according to the Hive CAIP-2 profile
+
+Validate the account name against Hive naming rules
+
+Query a Hive RPC endpoint to confirm account existence
+
+Account existence may be verified via:
+
+`condenser_api.get_accounts`
+
+`database_api.find_accounts`
+
+Security Considerations
+
+Hive account names are human-readable and may be subject to phishing using visually similar names.
+
+Applications SHOULD:
+
+Validate account existence before processing transactions
+
+Display full CAIP-10 identifiers when clarity is required
+
+Not assume account ownership without authority verification
+
+Because Hive supports multiple authorities (owner, active, posting), CAIP-10 identifiers represent accounts, not individual keys.
+
+Test Cases
+
+Valid:
+
+`hive:beeab0de000000000000000000000000:ecency`
+`hive:beeab0de000000000000000000000000:username`
+`hive:4200000000000000000000000000000:test-account`
+
+Invalid:
+
+`hive:beeab0de000000000000000000000000:UpperCase`
+`hive:beeab0de000000000000000000000000:ab`
+`hive:beeab0de000000000000000000000000:-invalid`
+
+References
+
+Hive configuration and account rules:
+https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+
+CAIP-10 specification:
+https://chainagnostic.org/CAIPs/caip-10
+
+Copyright
+
+Copyright and related rights waived via CC0 1.0.

--- a/hive/caip10.md
+++ b/hive/caip10.md
@@ -11,8 +11,7 @@ requires: ["CAIP-2", "CAIP-10"]
 
 # CAIP-10
 
-For context, see the CAIP-10 specification:
-https://chainagnostic.org/CAIPs/caip-10
+For context, see the [CAIP-10] specification.
 
 ## Rationale
 
@@ -25,11 +24,11 @@ Each Hive account name:
 - Is validated at the protocol level
 - Is constrained by naming rules enforced by consensus
 
-Because Hive accounts are stable identifiers and tied to a specific chain via `chain_id`, they are suitable for CAIP-10 account identifiers.
+Because Hive [accounts] are stable identifiers and tied to a specific chain via `chain_id`, they are suitable for CAIP-10 account identifiers.
 
 ## Specification
 
-A Hive CAIP-10 account identifier MUST follow:
+A Hive [CAIP-10] account identifier MUST follow:
 
 `hive:<reference>:<account>`
 
@@ -134,10 +133,10 @@ hive:beeab0de000000000000000000000000:has..double
 
 ## References
 
-- Hive configuration and account rules:
-  https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
-- CAIP-10 specification:
-  https://chainagnostic.org/CAIPs/caip-10
+- Hive configuration and [accounts] model
+
+[accounts]: https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+[CAIP-10]:   https://chainagnostic.org/CAIPs/caip-10
 
 ## Copyright
 

--- a/hive/caip2.md
+++ b/hive/caip2.md
@@ -1,0 +1,89 @@
+---
+namespace-identifier: hive-caip2
+title: Hive Namespace - CAIP-2 Chain Identifiers
+author: ["@feruzm"]
+discussions-to: 
+status: Draft
+type: Standard
+created: 2026-02-25
+requires: CAIP-2
+---
+
+# CAIP-2
+
+For context, see the CAIP-2 specification:
+https://chainagnostic.org/CAIPs/caip-2
+
+## Rationale
+
+Hive defines a 32-byte (`64` hex characters) `chain_id` value used for transaction signing and network identification.
+
+Because CAIP-2 restricts the `reference` field to a maximum of 32 characters, this specification defines the `reference` as:
+
+> The first 32 lowercase hexadecimal characters of Hive’s `chain_id`.
+
+This approach ensures:
+
+- Deterministic chain identification
+- Compatibility with CAIP-2 length constraints
+- Collision resistance appropriate for blockchain network identifiers
+- Alignment with other CAIP-2 namespace implementations
+
+## Specification
+
+### Namespace
+
+`hive`
+
+### Reference
+
+The `reference` MUST:
+
+- Be lowercase hexadecimal
+- Match the pattern: [0-9a-f]{32}
+
+### Resolution
+
+To derive a valid CAIP-2 identifier:
+
+1. Query a Hive node configuration.
+2. Retrieve the `chain_id` value.
+3. Convert to lowercase.
+4. Truncate to the first 32 hexadecimal characters.
+
+## Known Networks (Non-Normative Examples)
+
+### Hive Mainnet
+
+Full chain_id: `beeab0de00000000000000000000000000000000000000000000000000000000`
+CAIP-2: `hive:beeab0de000000000000000000000000`
+
+---
+
+### Hive Testnet
+
+Full chain_id: `42`
+CAIP-2: `42000000000000000000000000000000`
+
+
+## Security Considerations
+
+Applications MUST validate network configuration before accepting CAIP-2 identifiers.
+
+Hive uses account-based identity rather than address-based identity. Applications implementing CAIP-10 should validate account existence via RPC.
+
+## Test Cases
+
+hive:beeab0de000000000000000000000000
+hive:42000000000000000000000000000000
+
+
+## References
+
+Hive configuration documentation:
+https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+
+## Copyright
+
+Copyright and related rights waived via CC0 1.0.
+

--- a/hive/caip2.md
+++ b/hive/caip2.md
@@ -11,8 +11,7 @@ requires: CAIP-2
 
 # CAIP-2
 
-For context, see the CAIP-2 specification:
-https://chainagnostic.org/CAIPs/caip-2
+For context, see the [CAIP-2] specification:
 
 ## Rationale
 
@@ -25,7 +24,7 @@ Because CAIP-2 restricts the `reference` field to a maximum of 32 characters, th
 This approach ensures:
 
 - Deterministic chain identification
-- Compatibility with CAIP-2 length constraints
+- Compatibility with [CAIP-2] length constraints
 - Collision resistance appropriate for blockchain network identifiers
 - Alignment with other CAIP-2 namespace implementations
 
@@ -44,7 +43,7 @@ The `reference` MUST:
 
 ### Resolution
 
-To derive a valid CAIP-2 identifier:
+To derive a valid [CAIP-2] identifier:
 
 1. Query a Hive node using `database_api.get_config`.
 2. Retrieve the `HIVE_CHAIN_ID` value from the response.
@@ -87,9 +86,9 @@ CAIP-2: `hive:42000000000000000000000000000000` (zero-padded to 32 hex character
 
 ## Security Considerations
 
-Applications MUST validate network configuration before accepting CAIP-2 identifiers.
+Applications MUST validate network configuration before accepting [CAIP-2] identifiers.
 
-Hive uses account-based identity rather than address-based identity. Applications implementing CAIP-10 should validate account existence via RPC.
+Hive uses account-based identity rather than address-based identity. Applications implementing [CAIP-10] should validate account existence via RPC.
 
 ## Test Cases
 
@@ -100,10 +99,11 @@ hive:42000000000000000000000000000000
 
 ## References
 
-- Hive configuration documentation:
-  https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
-- CAIP-2 specification:
-  https://chainagnostic.org/CAIPs/caip-2
+- Hive [configuration]
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
+[configuration]: https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
 
 ## Copyright
 

--- a/hive/caip2.md
+++ b/hive/caip2.md
@@ -20,7 +20,7 @@ Hive defines a 32-byte (`64` hex characters) `chain_id` value used for transacti
 
 Because CAIP-2 restricts the `reference` field to a maximum of 32 characters, this specification defines the `reference` as:
 
-> The first 32 lowercase hexadecimal characters of Hive’s `chain_id`.
+> The first 32 lowercase hexadecimal characters of Hive's `chain_id`.
 
 This approach ensures:
 
@@ -40,16 +40,34 @@ This approach ensures:
 The `reference` MUST:
 
 - Be lowercase hexadecimal
-- Match the pattern: [0-9a-f]{32}
+- Match the pattern: `[0-9a-f]{32}`
 
 ### Resolution
 
 To derive a valid CAIP-2 identifier:
 
-1. Query a Hive node configuration.
-2. Retrieve the `chain_id` value.
+1. Query a Hive node using `database_api.get_config`.
+2. Retrieve the `HIVE_CHAIN_ID` value from the response.
 3. Convert to lowercase.
 4. Truncate to the first 32 hexadecimal characters.
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "database_api.get_config",
+  "id": 1
+}
+```
+
+#### Example Response (partial)
+
+```json
+{
+  "HIVE_CHAIN_ID": "beeab0de00000000000000000000000000000000000000000000000000000000"
+}
+```
 
 ## Known Networks (Non-Normative Examples)
 
@@ -60,11 +78,12 @@ CAIP-2: `hive:beeab0de000000000000000000000000`
 
 ---
 
-### Hive Testnet
+### Hive Mirrornet
 
 Full chain_id: `42`
-CAIP-2: `42000000000000000000000000000000`
+CAIP-2: `hive:42000000000000000000000000000000` (zero-padded to 32 hex characters)
 
+> **Note:** The mirrornet is a periodic snapshot of mainnet used for testing. There is no permanent public testnet at this time; mirrornet instances are ephemeral.
 
 ## Security Considerations
 
@@ -74,16 +93,18 @@ Hive uses account-based identity rather than address-based identity. Application
 
 ## Test Cases
 
+```
 hive:beeab0de000000000000000000000000
 hive:42000000000000000000000000000000
-
+```
 
 ## References
 
-Hive configuration documentation:
-https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+- Hive configuration documentation:
+  https://developers.hive.io/tutorials-recipes/understanding-configuration-values.html
+- CAIP-2 specification:
+  https://chainagnostic.org/CAIPs/caip-2
 
 ## Copyright
 
 Copyright and related rights waived via CC0 1.0.
-

--- a/hive/caip2.md
+++ b/hive/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: hive-caip2
 title: Hive Namespace - CAIP-2 Chain Identifiers
 author: ["@feruzm"]
-discussions-to: 
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/174
 status: Draft
 type: Standard
 created: 2026-02-25


### PR DESCRIPTION
This PR introduces the hive namespace to the ChainAgnostic namespaces registry and defines:

A CAIP-2 profile for Hive chain identifiers

A CAIP-10 profile for Hive account identifiers

[Hive](https://hive.io) is a delegated proof-of-stake blockchain focused on publishing, social and financial applications and fee-less transactions. Registering this namespace enables standardized multichain identification and interoperability.