### PR TITLE
feat: add dashevo namespace for Dash Platform WalletConnect support

### DIFF
--- a/dashevo/README.md
+++ b/dashevo/README.md
@@ -1,0 +1,70 @@
+---
+namespace-identifier: dashevo
+title: Dash Platform (Evo)
+author: ["PastaPastaPasta (@PastaPastaPasta)"]
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/177
+status: Draft
+type: Informational
+created: 2026-03-11
+updated: 2026-03-11
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# Namespace for Dash Platform
+
+[Dash Platform][] is an application layer built on top of the [Dash][] payment
+network. It uses [Tenderdash][] (a Dash fork of Tendermint) for consensus and
+provides a decentralized identity and data contract system. Unlike Dash Core,
+which operates on a UTXO-based payment model under the [bip122][] namespace,
+Dash Platform uses an identity-based account model where users register
+identities, deploy data contracts, and create documents on a separate consensus
+layer.
+
+## Rationale
+
+A separate namespace is required because Dash Platform differs fundamentally
+from Dash Core (bip122) in every dimension relevant to chain addressing:
+
+- **Consensus engine**: Tenderdash (Tendermint fork) vs Bitcoin-derived PoW/PoSe
+- **Account model**: Identity-based (256-bit identifiers) vs UTXO-based addresses
+- **State model**: Data contracts and documents vs transactions and outputs
+- **Transport**: gRPC via [DAPI][] vs Bitcoin JSON-RPC
+- **Chain IDs**: Tenderdash string identifiers (e.g. `evo1`) vs block hash genesis references
+
+These differences mean that CAIP-2 chain references, CAIP-10 account
+identifiers, and any higher-level CAIPs would have entirely incompatible
+semantics if forced into the bip122 namespace.
+
+## Governance
+
+Dash Platform is governed through the [Dash Improvement Proposal][DIP] process.
+Protocol changes are proposed as DIPs, discussed by the community, and
+implemented by [Dash Core Group][DCG]. The Tenderdash consensus layer inherits
+governance from the broader Dash masternode network, where masternodes vote on
+proposals and protocol upgrades.
+
+## References
+
+- [Dash][] - Dash project homepage
+- [Dash Platform docs][] - Official Dash Platform documentation
+- [Dash Platform][] - Dash Platform monorepo (source code)
+- [Tenderdash][] - Tenderdash consensus engine (Dash fork of Tendermint)
+- [DAPI][] - Decentralized API for Dash Platform
+- [DIP][] - Dash Improvement Proposals
+- [DCG][] - Dash Core Group
+- [bip122][] - BIP122 namespace used by Dash Core for payment transactions
+
+[Dash]: https://www.dash.org/
+[Dash Platform docs]: https://docs.dash.org/
+[Tenderdash]: https://github.com/dashpay/tenderdash
+[DAPI]: https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html
+[DIP]: https://github.com/dashpay/dips
+[Dash Platform]: https://github.com/dashpay/platform
+[DCG]: https://www.dash.org/dcg/
+[bip122]: https://github.com/ChainAgnostic/namespaces/tree/main/bip122
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/dashevo/README.md
+++ b/dashevo/README.md
@@ -12,13 +12,9 @@ requires: ["CAIP-2", "CAIP-10"]
 
 # Namespace for Dash Platform
 
-[Dash Platform][] is an application layer built on top of the [Dash][] payment
-network. It uses [Tenderdash][] (a Dash fork of Tendermint) for consensus and
-provides a decentralized identity and data contract system. Unlike Dash Core,
-which operates on a UTXO-based payment model under the [bip122][] namespace,
-Dash Platform uses an identity-based account model where users register
-identities, deploy data contracts, and create documents on a separate consensus
-layer.
+[Dash Platform][] is an application layer built on top of the [Dash][] payment network.
+It uses [Tenderdash][] (a Dash fork of Tendermint) for consensus and provides a decentralized identity and data contract system.
+Unlike Dash Core, which operates on a UTXO-based payment model under the [bip122][] namespace, Dash Platform uses an identity-based account model where users register identities, deploy data contracts, and create documents on a separate consensus layer.
 
 ## Rationale
 
@@ -33,15 +29,13 @@ from Dash Core (bip122) in every dimension relevant to chain addressing:
 
 These differences mean that CAIP-2 chain references, CAIP-10 account
 identifiers, and any higher-level CAIPs would have entirely incompatible
-semantics if forced into the bip122 namespace.
+semantics if forced into the [bip122][] namespace.
 
 ## Governance
 
 Dash Platform is governed through the [Dash Improvement Proposal][DIP] process.
-Protocol changes are proposed as DIPs, discussed by the community, and
-implemented by [Dash Core Group][DCG]. The Tenderdash consensus layer inherits
-governance from the broader Dash masternode network, where masternodes vote on
-proposals and protocol upgrades.
+Protocol changes are proposed as DIPs, discussed by the community, and implemented by [Dash Core Group][DCG].
+The Tenderdash consensus layer inherits governance from the broader Dash masternode network, where masternodes vote on proposals and protocol upgrades.
 
 ## References
 

--- a/dashevo/caip10.md
+++ b/dashevo/caip10.md
@@ -16,64 +16,56 @@ requires: ["CAIP-2", "CAIP-10"]
 
 ## Introduction
 
-Dash Platform uses an identity-based account model. Each identity is a
-first-class on-chain object that owns cryptographic keys, holds Platform
-credits, and can create or update data contracts and documents. This is
-fundamentally different from Dash Core's UTXO address model — Platform
-identities are persistent entities, not ephemeral transaction outputs.
+Dash Platform uses an identity-based account model.
+Each identity is a first-class on-chain object that owns cryptographic keys, holds Platform credits, and can create or update data contracts and documents.
+This is fundamentally different from Dash Core's UTXO address model — Platform identities are persistent entities, not ephemeral transaction outputs.
 
 ## Specification
 
 ### Semantics
 
-A Dash Platform identity is identified by a 256-bit (32-byte) identifier
-derived from the funding outpoint that created it:
+A Dash Platform identity is identified by a 256-bit (32-byte) identifier derived from the funding outpoint that created it:
 
-```
+```sh
 identity_id = sha256(sha256(funding_outpoint))
 ```
 
-The `funding_outpoint` is the serialized Dash Core transaction output (txid +
-output index) used to fund the identity creation. The double-SHA-256 ensures a
-deterministic, collision-resistant mapping from a Layer 1 transaction to a
-Platform identity.
+The `funding_outpoint` is the serialized Dash Core transaction output (txid + output index) used to fund the identity creation.
+The double-SHA-256 ensures a deterministic, collision-resistant mapping from a Layer 1 transaction to a Platform identity.
 
-The resulting 32-byte identifier is encoded in [base58][] (not base58check —
-there is no checksum byte). The typical encoded length is 43-44 characters.
+The resulting 32-byte identifier is encoded in `[base58][]` (NOT `[base58check][]` — there is no checksum byte).
+The typical encoded length is 43-44 characters.
 
 ### Syntax
 
-The CAIP-10 identifier for a Dash Platform identity is:
+The [CAIP-10][] identifier for a Dash Platform identity is:
 
-```
+```sh
 dashevo:<chain_id>:<identity_id_base58>
 ```
 
 Where:
-- `<chain_id>` is the Tenderdash chain ID as specified in the [CAIP-2 profile][]
+
+- `<chain_id>` is the Tenderdash chain ID as specified in the [CAIP-2 profile](./caip2.md)
 - `<identity_id_base58>` is the base58-encoded 256-bit identity identifier
 
-The regular expression for the account address portion (the `identity_id_base58`
-segment) is:
+The regular expression for the account address portion (the `identity_id_base58` segment) is:
 
-```
+```sh
 [1-9A-HJ-NP-Za-km-z]{43,44}
 ```
 
-This matches the base58 alphabet (Bitcoin-style, excluding `0`, `O`, `I`, `l`)
-with a maximum length of 44 characters (the longest possible base58 encoding of
-a 32-byte value).
+This matches the base58 alphabet (Bitcoin-style, excluding `0`, `O`, `I`, `l`) with a maximum length of 44 characters (the longest possible base58 encoding of a 32-byte value).
 
-The full CAIP-10 regular expression is:
+The full [CAIP-10][] regular expression is:
 
-```
+```sh
 dashevo:[-a-zA-Z0-9]{1,32}:[1-9A-HJ-NP-Za-km-z]{43,44}
 ```
 
 ### Resolution Mechanics
 
-To verify that an identity exists on a given chain, query the Platform's
-identity endpoint via [DAPI][]:
+To verify that an identity exists on a given chain, query the Platform's identity endpoint via [DAPI][]:
 
 ```jsonc
 // Request (DAPI gRPC — conceptual representation)
@@ -90,26 +82,18 @@ platform.getIdentity({ id: "<identity_id_bytes>" })
 }
 ```
 
-The identity's `publicKeys` array contains the cryptographic keys authorized to
-sign state transitions on behalf of this identity.
+The identity's `publicKeys` array contains any cryptographic keys authorized to sign state transitions on behalf of this identity.
 
 ## Rationale
 
-The identity-based account model was chosen for Dash Platform because it
-supports persistent, key-rotatable identities that can own data contracts and
-documents — concepts that do not exist in the UTXO model. The double-SHA-256
-derivation from a funding outpoint provides a deterministic link between Layer 1
-(Dash Core) and Layer 2 (Dash Platform) without requiring any additional
-registration protocol beyond the identity creation state transition.
+The identity-based account model was chosen for Dash Platform because it supports persistent, key-rotatable identities that can own data contracts and documents — concepts that do not exist in the UTXO model.
+The double-SHA-256 derivation from a funding outpoint provides a deterministic link between Layer 1 (Dash Core) and Layer 2 (Dash Platform) without requiring any additional registration protocol beyond the identity creation state transition.
 
-Base58 encoding (without checksum) is used because Platform identity IDs are
-always validated against chain state — the checksum byte used in Dash Core
-addresses (base58check) is unnecessary when the canonical identifier is the raw
-32 bytes stored on-chain.
+[Base58][] encoding (without checksum) is used because Platform identity IDs are always validated against chain state — the checksum byte used in Dash Core addresses (base58check) is unnecessary when the canonical identifier is the raw 32 bytes stored on-chain.
 
 ## Test Cases
 
-```
+```sh
 # Mainnet identity
 dashevo:evo1:EWSqsaghuwHRjtutbXK3nR11KbRkg9a12PNAAkJWRTpY
 
@@ -129,6 +113,7 @@ dashevo:dash-testnet-51:GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
 [CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
 [Dash Platform identity docs]: https://docs.dash.org/projects/platform/en/stable/docs/explanation/identity.html
 [base58]: https://en.bitcoin.it/wiki/Base58
+[base58check]: https://en.bitcoin.it/wiki/Base58Check_encoding
 [DAPI]: https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html
 
 ## Copyright

--- a/dashevo/caip10.md
+++ b/dashevo/caip10.md
@@ -1,0 +1,136 @@
+---
+namespace-identifier: dashevo-caip10
+title: Dash Platform Namespace - Accounts
+author: ["PastaPastaPasta (@PastaPastaPasta)"]
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/177
+status: Draft
+type: Informational
+created: 2026-03-11
+updated: 2026-03-11
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+## Introduction
+
+Dash Platform uses an identity-based account model. Each identity is a
+first-class on-chain object that owns cryptographic keys, holds Platform
+credits, and can create or update data contracts and documents. This is
+fundamentally different from Dash Core's UTXO address model — Platform
+identities are persistent entities, not ephemeral transaction outputs.
+
+## Specification
+
+### Semantics
+
+A Dash Platform identity is identified by a 256-bit (32-byte) identifier
+derived from the funding outpoint that created it:
+
+```
+identity_id = sha256(sha256(funding_outpoint))
+```
+
+The `funding_outpoint` is the serialized Dash Core transaction output (txid +
+output index) used to fund the identity creation. The double-SHA-256 ensures a
+deterministic, collision-resistant mapping from a Layer 1 transaction to a
+Platform identity.
+
+The resulting 32-byte identifier is encoded in [base58][] (not base58check —
+there is no checksum byte). The typical encoded length is 43-44 characters.
+
+### Syntax
+
+The CAIP-10 identifier for a Dash Platform identity is:
+
+```
+dashevo:<chain_id>:<identity_id_base58>
+```
+
+Where:
+- `<chain_id>` is the Tenderdash chain ID as specified in the [CAIP-2 profile][]
+- `<identity_id_base58>` is the base58-encoded 256-bit identity identifier
+
+The regular expression for the account address portion (the `identity_id_base58`
+segment) is:
+
+```
+[1-9A-HJ-NP-Za-km-z]{43,44}
+```
+
+This matches the base58 alphabet (Bitcoin-style, excluding `0`, `O`, `I`, `l`)
+with a maximum length of 44 characters (the longest possible base58 encoding of
+a 32-byte value).
+
+The full CAIP-10 regular expression is:
+
+```
+dashevo:[-a-zA-Z0-9]{1,32}:[1-9A-HJ-NP-Za-km-z]{43,44}
+```
+
+### Resolution Mechanics
+
+To verify that an identity exists on a given chain, query the Platform's
+identity endpoint via [DAPI][]:
+
+```jsonc
+// Request (DAPI gRPC — conceptual representation)
+platform.getIdentity({ id: "<identity_id_bytes>" })
+
+// Response
+{
+  "identity": {
+    "id": "EWSqsaghuwHRjtutbXK3nR11KbRkg9a12PNAAkJWRTpY",
+    "publicKeys": [ ... ],
+    "balance": 1000000,
+    "revision": 1
+  }
+}
+```
+
+The identity's `publicKeys` array contains the cryptographic keys authorized to
+sign state transitions on behalf of this identity.
+
+## Rationale
+
+The identity-based account model was chosen for Dash Platform because it
+supports persistent, key-rotatable identities that can own data contracts and
+documents — concepts that do not exist in the UTXO model. The double-SHA-256
+derivation from a funding outpoint provides a deterministic link between Layer 1
+(Dash Core) and Layer 2 (Dash Platform) without requiring any additional
+registration protocol beyond the identity creation state transition.
+
+Base58 encoding (without checksum) is used because Platform identity IDs are
+always validated against chain state — the checksum byte used in Dash Core
+addresses (base58check) is unnecessary when the canonical identifier is the raw
+32 bytes stored on-chain.
+
+## Test Cases
+
+```
+# Mainnet identity
+dashevo:evo1:EWSqsaghuwHRjtutbXK3nR11KbRkg9a12PNAAkJWRTpY
+
+# Testnet identity
+dashevo:dash-testnet-51:GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+```
+
+## References
+
+- [CAIP-2 Profile][] - Dash Platform CAIP-2 chain identification
+- [Dash Platform identity docs][] - Official documentation on Platform identities
+- [base58][] - Base58 encoding reference (Bitcoin wiki)
+- [DAPI][] - Decentralized API for querying Platform state
+
+[CAIP-2 Profile]: ./caip2.md
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
+[Dash Platform identity docs]: https://docs.dash.org/projects/platform/en/stable/docs/explanation/identity.html
+[base58]: https://en.bitcoin.it/wiki/Base58
+[DAPI]: https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/dashevo/caip2.md
+++ b/dashevo/caip2.md
@@ -16,21 +16,17 @@ requires: CAIP-2
 
 ## Introduction
 
-Dash Platform chains are identified by string-based chain IDs assigned at
-genesis by [Tenderdash][], a Dash fork of Tendermint. Each network (mainnet,
-testnet, devnet) has a distinct `chain_id` that is returned by every node in
-that network. This is the same pattern used by the Cosmos ecosystem, but with a
-separate namespace because Dash Platform is an independent consensus layer with
-its own identity and data contract system.
+Dash Platform chains are identified by string-based chain IDs assigned at genesis by [Tenderdash][], a Dash fork of Tendermint.
+Each network (mainnet, testnet, devnet) has a distinct `chain_id` that is returned by every node in that network.
+This is the same pattern used by the Cosmos ecosystem, but with a separate namespace because Dash Platform is an independent consensus layer with its own identity and data contract system.
 
 ## Specification
 
 ### Semantics
 
-The `chain_id` is a string identifier set in the Tenderdash genesis
-configuration. It uniquely identifies a Dash Platform network. The value is
-immutable for the lifetime of a network — if a network is reset, a new
-`chain_id` is assigned.
+The `chain_id` is a string identifier set in the Tenderdash genesis configuration.
+It uniquely identifies a Dash Platform network.
+The value is immutable for the lifetime of a network — if a network is reset, a new `chain_id` is assigned.
 
 Known chain IDs:
 
@@ -39,32 +35,29 @@ Known chain IDs:
 | Mainnet  | `evo1`             |
 | Testnet  | `dash-testnet-51`  |
 
-These values are sourced from the [Platform source code][chain-id-source]
-(`getMainnetConfigFactory.js` and `getTestnetConfigFactory.js`).
+These values are sourced from the [Platform source code][chain-id-source] (see `getMainnetConfigFactory.js` and `getTestnetConfigFactory.js`).
 
 ### Syntax
 
-The CAIP-2 identifier for Dash Platform chains is formed by prefixing the
-namespace `dashevo:` to the Tenderdash `chain_id`:
+The CAIP-2 identifier for Dash Platform chains is formed by prefixing the namespace `dashevo:` to the Tenderdash `chain_id`:
 
-```
+```sh
 dashevo:<chain_id>
 ```
 
 The `chain_id` (used as the CAIP-2 `reference`) matches the following regular
 expression:
 
-```
+```sh
 [-a-zA-Z0-9]{1,32}
 ```
 
-This is the same character class as Cosmos direct references, reflecting the
-shared Tendermint heritage.
+This is the same character class as [Cosmos direct references](../cosmos/caip2.md), reflecting the shared Tendermint heritage.
 
 ### Resolution Mechanics
 
-To verify a chain ID, query any Tenderdash node's status endpoint. The
-`chain_id` appears in the `network` field of the node info response.
+To verify a chain ID, query any Tenderdash node's status endpoint.
+The `chain_id` appears in the `network` field of the `node_info` response.
 
 ```jsonc
 // Request (Tenderdash RPC)
@@ -79,29 +72,22 @@ curl -sS https://seed-1.testnet.networks.dash.org:1443/status | jq .result.node_
 ```
 
 For mainnet, query a mainnet Tenderdash node using the same `/status` path.
-The `network` field in the response can be used directly as the `reference`
-portion of the CAIP-2 identifier.
+The `network` field in the response can be used directly as the `reference` portion of the [CAIP-2][] identifier.
 
-Note: These are documentation endpoints for chain verification. They are not
-required by the WalletConnect relay protocol and are not embedded in session
-proposals.
+Note: These are documentation endpoints for chain verification.
+They are NOT required by the WalletConnect relay protocol and are NOT embedded in [CAIP-25][] session proposals.
 
 ## Rationale
 
-Dash Platform chain IDs follow the Tendermint convention of human-readable
-string identifiers set at genesis. The `evo1` mainnet identifier and
-`dash-testnet-51` testnet identifier are simple strings that fit within the
-32-character limit of CAIP-2 references and match the `[-a-zA-Z0-9]{1,32}`
-pattern without requiring hashing.
+Dash Platform chain IDs follow the [Tendermint convention](../cosmos/caip2.md) of human-readable string identifiers set at genesis.
+The `evo1` mainnet identifier and `dash-testnet-51` testnet identifier are simple strings that fit within the 32-character limit of CAIP-2 references and match the `[-a-zA-Z0-9]{1,32}` pattern without requiring hashing.
 
-The namespace `dashevo` was chosen to distinguish Dash Platform from Dash Core
-(which uses the `bip122` namespace). "Evo" is the community name for Dash
-Platform (short for "Evolution"), making `dashevo` immediately recognizable to
-Dash ecosystem participants.
+The namespace `dashevo` was chosen to distinguish Dash Platform from Dash Core (which uses the `bip122` namespace).
+"Evo" is the community name for Dash Platform (short for "Evolution"), making `dashevo` recognizable to Dash ecosystem participants.
 
 ## Test Cases
 
-```
+```sh
 # Mainnet
 dashevo:evo1
 
@@ -121,6 +107,7 @@ dashevo:dash-testnet-51
 [DAPI endpoints]: https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html
 [chain-id-source]: https://github.com/dashpay/platform
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-25]: https://chainagnostic.org/CAIPs/caip-25
 
 ## Copyright
 

--- a/dashevo/caip2.md
+++ b/dashevo/caip2.md
@@ -1,0 +1,127 @@
+---
+namespace-identifier: dashevo-caip2
+title: Dash Platform Namespace - Chains
+author: ["PastaPastaPasta (@PastaPastaPasta)"]
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/177
+status: Draft
+type: Informational
+created: 2026-03-11
+updated: 2026-03-11
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Introduction
+
+Dash Platform chains are identified by string-based chain IDs assigned at
+genesis by [Tenderdash][], a Dash fork of Tendermint. Each network (mainnet,
+testnet, devnet) has a distinct `chain_id` that is returned by every node in
+that network. This is the same pattern used by the Cosmos ecosystem, but with a
+separate namespace because Dash Platform is an independent consensus layer with
+its own identity and data contract system.
+
+## Specification
+
+### Semantics
+
+The `chain_id` is a string identifier set in the Tenderdash genesis
+configuration. It uniquely identifies a Dash Platform network. The value is
+immutable for the lifetime of a network — if a network is reset, a new
+`chain_id` is assigned.
+
+Known chain IDs:
+
+| Network  | chain_id           |
+|----------|--------------------|
+| Mainnet  | `evo1`             |
+| Testnet  | `dash-testnet-51`  |
+
+These values are sourced from the [Platform source code][chain-id-source]
+(`getMainnetConfigFactory.js` and `getTestnetConfigFactory.js`).
+
+### Syntax
+
+The CAIP-2 identifier for Dash Platform chains is formed by prefixing the
+namespace `dashevo:` to the Tenderdash `chain_id`:
+
+```
+dashevo:<chain_id>
+```
+
+The `chain_id` (used as the CAIP-2 `reference`) matches the following regular
+expression:
+
+```
+[-a-zA-Z0-9]{1,32}
+```
+
+This is the same character class as Cosmos direct references, reflecting the
+shared Tendermint heritage.
+
+### Resolution Mechanics
+
+To verify a chain ID, query any Tenderdash node's status endpoint. The
+`chain_id` appears in the `network` field of the node info response.
+
+```jsonc
+// Request (Tenderdash RPC)
+curl -sS https://seed-1.testnet.networks.dash.org:1443/status | jq .result.node_info
+
+// Response (relevant fields)
+{
+  "network": "dash-testnet-51",
+  "version": "1.3.0",
+  ...
+}
+```
+
+For mainnet, query a mainnet Tenderdash node using the same `/status` path.
+The `network` field in the response can be used directly as the `reference`
+portion of the CAIP-2 identifier.
+
+Note: These are documentation endpoints for chain verification. They are not
+required by the WalletConnect relay protocol and are not embedded in session
+proposals.
+
+## Rationale
+
+Dash Platform chain IDs follow the Tendermint convention of human-readable
+string identifiers set at genesis. The `evo1` mainnet identifier and
+`dash-testnet-51` testnet identifier are simple strings that fit within the
+32-character limit of CAIP-2 references and match the `[-a-zA-Z0-9]{1,32}`
+pattern without requiring hashing.
+
+The namespace `dashevo` was chosen to distinguish Dash Platform from Dash Core
+(which uses the `bip122` namespace). "Evo" is the community name for Dash
+Platform (short for "Evolution"), making `dashevo` immediately recognizable to
+Dash ecosystem participants.
+
+## Test Cases
+
+```
+# Mainnet
+dashevo:evo1
+
+# Testnet
+dashevo:dash-testnet-51
+```
+
+## References
+
+- [Tenderdash][] - Tenderdash consensus engine repository
+- [Dash Platform docs][] - Official Dash Platform documentation
+- [DAPI endpoints][] - DAPI endpoint reference for querying Platform state
+- [chain-id-source][] - Platform source code where chain IDs are defined
+
+[Tenderdash]: https://github.com/dashpay/tenderdash
+[Dash Platform docs]: https://docs.dash.org/
+[DAPI endpoints]: https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html
+[chain-id-source]: https://github.com/dashpay/platform
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

Adds the `dashevo` namespace for [Dash Platform](https://github.com/dashpay/platform), the identity and data contract layer built on top of the Dash payment network.

Dash Platform uses [Tenderdash](https://github.com/dashpay/tenderdash) (a Dash fork of Tendermint) for consensus and an identity-based account model — fundamentally different from Dash Core, which already has a listing under the `bip122` namespace. This requires a separate namespace because the consensus engine, account model, state model, and transport are all incompatible with `bip122`.

### Files

- **`dashevo/README.md`** — Namespace overview, rationale for separation from `bip122`, governance
- **`dashevo/caip2.md`** — Chain identification using Tenderdash `chain_id` strings (`evo1` for mainnet, `dash-testnet-51` for testnet)
- **`dashevo/caip10.md`** — Account identification using base58-encoded 256-bit Platform identity IDs

### Key design decisions

- Chain IDs follow the Tendermint/Cosmos pattern (string identifiers from genesis config), regex: `[-a-zA-Z0-9]{1,32}`
- Identity IDs are `sha256(sha256(funding_outpoint))`, base58-encoded (no checksum), 43-44 characters, regex: `[1-9A-HJ-NP-Za-km-z]{43,44}`
- Resolution mechanics document Tenderdash RPC and DAPI endpoints for verification

### Related

- Dash Core WalletConnect listing: [walletconnect-monorepo#7141](https://github.com/AW-AlanBian/walletconnect-monorepo/issues/7141) (uses `bip122`)
- [Dash Platform documentation](https://docs.dash.org/)