### PR TITLE
Add `atto` namespace and CAIP-2 specification

### DIFF
--- a/atto/README.md
+++ b/atto/README.md
@@ -26,21 +26,27 @@ A dedicated namespace allows tools to refer to Atto deployment environments cons
 
 ## Governance
 
-This namespace tracks the Atto protocol and its network identifiers as defined by the Atto ecosystem maintainers.
-Future CAIP profiles for Atto should follow this namespace to document account IDs, asset IDs, and other ecosystem-specific conventions.
-Public network naming should remain stable over time to ensure long-term interoperability.
+This namespace tracks the public Atto protocol as documented by the ecosystem's maintainers.
+Protocol-level changes and governance-relevant decisions should be validated against public Atto materials, especially the whitepaper and official documentation, and against the implementation history in the public GitHub repositories.
+Future updates to this namespace should cite those sources when describing changes to network behavior, distribution, staking, or other community-facing protocol decisions.
 
 ## References
 
 - [Documentation][] - Official documentation for the Atto ecosystem.
+- [Whitepaper][] - Public protocol and governance context, including decentralization and representative voting.
 - [Node API Reference][] - Reference for the Atto node RPC and REST interfaces.
 - [Integration Guide][] - Overview of Atto components, integration model, and operational guidance.
-- [GitHub][] - Source code and development resources.
+- [Blog][] - Public announcements and writeups for major ecosystem and protocol changes.
+- [GitHub][] - Source code, issues, and pull requests for implementation history and concrete protocol updates.
+- [Node Repository][] - Reference implementation of the Atto node and consensus behavior.
 
 [Documentation]: https://atto.cash/docs
+[Whitepaper]: https://atto.cash/docs/whitepaper
 [Node API Reference]: https://atto.cash/api/node
 [Integration Guide]: https://atto.cash/docs/integration
+[Blog]: https://atto.cash/blog
 [GitHub]: https://github.com/attocash
+[Node Repository]: https://github.com/attocash/node
 
 ## Copyright
 

--- a/atto/README.md
+++ b/atto/README.md
@@ -1,0 +1,47 @@
+---
+namespace-identifier: atto
+title: Atto Ecosystem
+author: Felipe Rotilho (@rotilho)
+status: Draft
+type: Informational
+created: 2026-03-18
+---
+
+# Namespace for Atto Networks
+
+## Introduction
+
+The `atto` namespace refers to the Atto ecosystem:
+a feeless account-chain payment network where value transfers are represented as native Atto blocks and transactions.
+
+Atto is a native layer-1 system with its own chain model, transaction encoding, and account addressing, all defined by the Atto protocol.
+
+The purpose of this namespace is to provide stable chain identifiers for Atto networks and a neutral reference point for cross-chain tooling built on CAIPs.
+
+## Rationale
+
+Atto needs its own namespace because it introduces a distinct execution and validation model.
+Native account-chain semantics, address encoding, and transaction serialization do not fit under existing namespaces such as EVM, Solana, or Stellar.
+A dedicated namespace allows tools to refer to Atto deployment environments consistently using human-readable CAIP-2 identifiers.
+
+## Governance
+
+This namespace tracks the Atto protocol and its network identifiers as defined by the Atto ecosystem maintainers.
+Future CAIP profiles for Atto should follow this namespace to document account IDs, asset IDs, and other ecosystem-specific conventions.
+Public network naming should remain stable over time to ensure long-term interoperability.
+
+## References
+
+- [Documentation][] - Official documentation for the Atto ecosystem.
+- [Node API Reference][] - Reference for the Atto node RPC and REST interfaces.
+- [Integration Guide][] - Overview of Atto components, integration model, and operational guidance.
+- [GitHub][] - Source code and development resources.
+
+[Documentation]: https://atto.cash/docs
+[Node API Reference]: https://atto.cash/api/node
+[Integration Guide]: https://atto.cash/docs/integration
+[GitHub]: https://github.com/attocash
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/atto/README.md
+++ b/atto/README.md
@@ -12,7 +12,7 @@ created: 2026-03-18
 ## Introduction
 
 The `atto` namespace refers to the Atto ecosystem:
-a feeless account-chain payment network where value transfers are represented as native Atto blocks and transactions.
+a fee-less account-chain payment network where value transfers are represented as native Atto blocks and transactions.
 
 Atto is a native layer-1 system with its own chain model, transaction encoding, and account addressing, all defined by the Atto protocol.
 

--- a/atto/caip2.md
+++ b/atto/caip2.md
@@ -16,20 +16,17 @@ requires: CAIP-2
 ## Introduction
 
 The `atto` namespace identifies Atto chains.
-Atto is a native layer-1 payment network with an account-chain model, native address format, native transaction
-serialization, and lightweight proof-of-work used for anti-spam rather than consensus.
+Atto is a native layer-1 payment network with an account-chain model, native address format, native transaction serialization, and lightweight proof-of-work used for anti-spam rather than consensus.
 
 A CAIP-2 identifier in this namespace takes the form `atto:<reference>`.
-The reference identifies a concrete Atto network environment such as mainnet, beta/test, development, or local/private
-development.
+The reference identifies a concrete Atto network environment such as mainnet, beta/test, development, or local/private development.
 
 ## Specification
 
 ### Semantics
 
 The `atto` namespace is intended for chains that use the native Atto protocol and validation model.
-A valid CAIP-2 identifier in this namespace refers to an Atto network that shares Atto's block model, address model,
-signing rules, and proof-of-work rules.
+A valid CAIP-2 identifier in this namespace refers to an Atto network that shares Atto's block model, address model, signing rules, and proof-of-work rules.
 
 The following references are defined by this draft:
 
@@ -65,39 +62,30 @@ Suggested validation regex:
 
 Implementations MUST treat the namespace component as exactly `atto`.
 Implementations SHOULD treat the reference component as lowercase.
-Unknown future references within the `atto` namespace SHOULD be rejected unless explicitly supported by the
-implementation.
+Unknown future references within the `atto` namespace SHOULD be rejected unless explicitly supported by the implementation.
 
 ### Resolution Mechanics
 
-Resolution of an Atto CAIP-2 identifier is performed by selecting a node or service configured for the corresponding
-Atto network environment.
-The identifier therefore resolves operationally through network-specific Atto infrastructure rather than through
-on-chain contract registries.
+Resolution of an Atto CAIP-2 identifier is performed by selecting a node or service configured for the corresponding Atto network environment.
+The identifier therefore resolves operationally through network-specific Atto infrastructure rather than through on-chain contract registries.
 
-For public/shared environments, implementations SHOULD map the following identifiers to their corresponding Atto
-deployments:
+For public/shared environments, implementations SHOULD map the following identifiers to their corresponding Atto deployments:
 
 - `atto:live` → mainnet infrastructure
 - `atto:beta` → public beta/test infrastructure
 - `atto:dev` → development infrastructure
 - `atto:local` → local/private development infrastructure
 
-If an implementation exposes multiple Atto environments, it MUST ensure that transactions, account state reads, and
-address validation are performed against infrastructure for the selected Atto chain only.
+If an implementation exposes multiple Atto environments, it MUST ensure that transactions, account state reads, and address validation are performed against infrastructure for the selected Atto chain only.
 
 ## Rationale
 
 Atto needs a dedicated namespace because its interoperability assumptions are not those of any existing namespace.
-The same client or wallet logic used for EVM, Stellar, or Solana cannot be reused without Atto-specific validation
-logic.
-Atto-native tooling must understand native account-chain state, native address encoding, and Atto-native transaction
-verification.
+The same client or wallet logic used for EVM, Stellar, or Solana cannot be reused without Atto-specific validation logic.
+Atto-native tooling must understand native account-chain state, native address encoding, and Atto-native transaction verification.
 
-The references `live`, `beta`, `dev`, and `local` are chosen because they are short, operationally intuitive, and
-consistent with how integrators commonly distinguish production, test, development, and local environments.
-This draft intentionally avoids deriving chain identifiers from opaque hashes or environment-specific values that are
-less legible for wallet and payment tooling.
+The references `live`, `beta`, `dev`, and `local` are chosen because they are short, operationally intuitive, and consistent with how integrators commonly distinguish production, test, development, and local environments.
+This draft intentionally avoids deriving chain identifiers from opaque hashes or environment-specific values that are less legible for wallet and payment tooling.
 
 ### Backwards Compatibility
 
@@ -136,13 +124,9 @@ Additional Atto namespace profiles may later define:
 - [GitHub][] - Source code and development resources.
 
 [Documentation]: https://atto.cash/docs
-
 [Node API Reference]: https://atto.cash/api/node
-
 [Integration Guide]: https://atto.cash/docs/integration
-
 [GitHub]: https://github.com/attocash
-
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 
 ## Copyright

--- a/atto/caip2.md
+++ b/atto/caip2.md
@@ -19,7 +19,7 @@ The `atto` namespace identifies Atto chains.
 Atto is a native layer-1 payment network with an account-chain model, native address format, native transaction serialization, and lightweight proof-of-work used for anti-spam rather than consensus.
 
 A CAIP-2 identifier in this namespace takes the form `atto:<reference>`.
-The reference identifies a concrete Atto network environment such as mainnet, beta/test, development, or local/private development.
+The reference identifies a concrete Atto network environment such as mainnet, beta/test, a shared development network, or an ephemeral local/private development network.
 
 ## Specification
 
@@ -32,11 +32,11 @@ The following references are defined by this draft:
 
 - `live` — Atto mainnet
 - `beta` — Atto public beta / test network
-- `dev` — Atto development network
-- `local` — local or private development network
+- `dev` — Atto public development network
+- `local` — ephemeral local/private network
 
-These references are intentionally short and stable.
-They are meant to be human-readable deployment identifiers rather than hashes of genesis state.
+`atto:dev` is intended for a development deployment that is reachable by multiple participants and stable enough for shared testing, integration work, or external references.
+`atto:local` is reserved for local-only, such as integration tests, benchmarks, and developer machines, where a fresh genesis may be created and no persistence or public discoverability is assumed.
 
 ### Syntax
 
@@ -73,8 +73,10 @@ For public/shared environments, implementations SHOULD map the following identif
 
 - `atto:live` → mainnet infrastructure
 - `atto:beta` → public beta/test infrastructure
-- `atto:dev` → development infrastructure
+- `atto:dev` → shared development infrastructure
 - `atto:local` → local/private development infrastructure
+
+Implementations SHOULD treat `atto:local` similarly to a localhost-style environment: it is not expected to name a globally shared network, and identifiers using it are not expected to remain reusable outside the local context in which they were created.
 
 If an implementation exposes multiple Atto environments, it MUST ensure that transactions, account state reads, and address validation are performed against infrastructure for the selected Atto chain only.
 
@@ -85,6 +87,8 @@ The same client or wallet logic used for EVM, Stellar, or Solana cannot be reuse
 Atto-native tooling must understand native account-chain state, native address encoding, and Atto-native transaction verification.
 
 The references `live`, `beta`, `dev`, and `local` are chosen because they are short, operationally intuitive, and consistent with how integrators commonly distinguish production, test, development, and local environments.
+This draft uses stable, human-readable environment names instead of genesis-derived identifiers, because Atto deployments are intended to be referenced operationally by role.
+This draft gives `local` stronger semantics than a generic development label: it is reserved for ephemeral or operator-scoped environments, while `dev` refers to a shared Atto development network that other participants may also target.
 This draft intentionally avoids deriving chain identifiers from opaque hashes or environment-specific values that are less legible for wallet and payment tooling.
 
 ### Backwards Compatibility
@@ -100,10 +104,10 @@ atto:live
 # Atto public beta / test network
 atto:beta
 
-# Atto development network
+# Atto shared development network
 atto:dev
 
-# Atto local / private development network
+# Atto ephemeral local / private development network
 atto:local
 ```
 

--- a/atto/caip2.md
+++ b/atto/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: atto-caip2
 title: Atto Namespace - Blockchain ID Specification
 author: Felipe Rotilho (@rotilho)
-discussions-to:
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/178
 status: Draft
 type: Standard
 created: 2026-03-18

--- a/atto/caip2.md
+++ b/atto/caip2.md
@@ -1,0 +1,150 @@
+---
+namespace-identifier: atto-caip2
+title: Atto Namespace - Blockchain ID Specification
+author: Felipe Rotilho (@rotilho)
+discussions-to:
+status: Draft
+type: Standard
+created: 2026-03-18
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Introduction
+
+The `atto` namespace identifies Atto chains.
+Atto is a native layer-1 payment network with an account-chain model, native address format, native transaction
+serialization, and lightweight proof-of-work used for anti-spam rather than consensus.
+
+A CAIP-2 identifier in this namespace takes the form `atto:<reference>`.
+The reference identifies a concrete Atto network environment such as mainnet, beta/test, development, or local/private
+development.
+
+## Specification
+
+### Semantics
+
+The `atto` namespace is intended for chains that use the native Atto protocol and validation model.
+A valid CAIP-2 identifier in this namespace refers to an Atto network that shares Atto's block model, address model,
+signing rules, and proof-of-work rules.
+
+The following references are defined by this draft:
+
+- `live` — Atto mainnet
+- `beta` — Atto public beta / test network
+- `dev` — Atto development network
+- `local` — local or private development network
+
+These references are intentionally short and stable.
+They are meant to be human-readable deployment identifiers rather than hashes of genesis state.
+
+### Syntax
+
+An Atto blockchain ID is a CAIP-2 string with namespace `atto` and a lowercase network reference.
+
+Canonical format:
+
+```text
+atto:<reference>
+```
+
+Reference values currently defined by this draft:
+
+```text
+live | beta | dev | local
+```
+
+Suggested validation regex:
+
+```text
+^atto:(live|beta|dev|local)$
+```
+
+Implementations MUST treat the namespace component as exactly `atto`.
+Implementations SHOULD treat the reference component as lowercase.
+Unknown future references within the `atto` namespace SHOULD be rejected unless explicitly supported by the
+implementation.
+
+### Resolution Mechanics
+
+Resolution of an Atto CAIP-2 identifier is performed by selecting a node or service configured for the corresponding
+Atto network environment.
+The identifier therefore resolves operationally through network-specific Atto infrastructure rather than through
+on-chain contract registries.
+
+For public/shared environments, implementations SHOULD map the following identifiers to their corresponding Atto
+deployments:
+
+- `atto:live` → mainnet infrastructure
+- `atto:beta` → public beta/test infrastructure
+- `atto:dev` → development infrastructure
+- `atto:local` → local/private development infrastructure
+
+If an implementation exposes multiple Atto environments, it MUST ensure that transactions, account state reads, and
+address validation are performed against infrastructure for the selected Atto chain only.
+
+## Rationale
+
+Atto needs a dedicated namespace because its interoperability assumptions are not those of any existing namespace.
+The same client or wallet logic used for EVM, Stellar, or Solana cannot be reused without Atto-specific validation
+logic.
+Atto-native tooling must understand native account-chain state, native address encoding, and Atto-native transaction
+verification.
+
+The references `live`, `beta`, `dev`, and `local` are chosen because they are short, operationally intuitive, and
+consistent with how integrators commonly distinguish production, test, development, and local environments.
+This draft intentionally avoids deriving chain identifiers from opaque hashes or environment-specific values that are
+less legible for wallet and payment tooling.
+
+### Backwards Compatibility
+
+Not applicable.
+
+## Test Cases
+
+```text
+# Atto mainnet
+atto:live
+
+# Atto public beta / test network
+atto:beta
+
+# Atto development network
+atto:dev
+
+# Atto local / private development network
+atto:local
+```
+
+## Additional Considerations
+
+This draft only defines CAIP-2 identifiers for Atto chains.
+Additional Atto namespace profiles may later define:
+
+- CAIP-10 account identifiers for Atto addresses
+- CAIP-19 asset identifiers for the native Atto asset and future asset models, if any
+- Other Atto-specific profiles where cross-chain tooling benefits from explicit namespace guidance
+
+## References
+
+- [Documentation][] - Official documentation for the Atto ecosystem.
+- [Node API Reference][] - Reference for the Atto node RPC and REST interfaces.
+- [Integration Guide][] - Overview of Atto components, integration model, and operational guidance.
+- [GitHub][] - Source code and development resources.
+
+[Documentation]: https://atto.cash/docs
+
+[Node API Reference]: https://atto.cash/api/node
+
+[Integration Guide]: https://atto.cash/docs/integration
+
+[GitHub]: https://github.com/attocash
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This PR proposes a new `atto` namespace for the Atto ecosystem and adds an initial CAIP-2 profile for Atto chain identifiers.

Why this should be its own namespace:
- Atto is a native layer-1 payment network, not an environment of an existing namespace.
- It has a distinct account-chain model, native address format, native transaction format, and native proof-of-work validation rules.
- Tools interacting with Atto need Atto-specific validation logic.