### PR TITLE
Add Movement namespace

### DIFF
--- a/movement/README.md
+++ b/movement/README.md
@@ -1,0 +1,32 @@
+---
+namespace-identifier: movement
+title: Movement Network
+author: Andy Golay (@andygolay)
+status: Draft
+type: Informational
+created: 2026-03-23
+requires: ["CAIP-2"]
+---
+
+# Namespace for Movement Network
+
+## Introduction
+
+Blockchains in the "movement" namespace are identified by their numeric `chain_id`;
+each network is maintained by a set of validators with its own REST API and
+indexer endpoints. Movement is a Layer 2 network built on Move, featuring
+parallel execution for high throughput.
+
+## Syntax
+
+The namespace "movement" refers to the Movement Network blockchain platform.
+
+## References
+
+[Movement Docs]: https://docs.movementnetwork.xyz/
+[Movement GitHub]: https://github.com/moveindustries
+[Movement Network Website]: https://movementnetwork.xyz/
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/movement/README.md
+++ b/movement/README.md
@@ -5,7 +5,7 @@ author: Andy Golay (@andygolay)
 status: Draft
 type: Informational
 created: 2026-03-23
-requires: ["CAIP-2"]
+requires: ["CAIP-2", "CAIP-10"]
 ---
 
 # Namespace for Movement Network

--- a/movement/caip10.md
+++ b/movement/caip10.md
@@ -1,0 +1,148 @@
+---
+namespace-identifier: movement-caip10
+title: Movement Namespace - CAIP-10 Account Identifiers
+author: Andy Golay (@andygolay)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/179
+status: Draft
+type: Standard
+created: 2026-03-23
+updated: 2026-03-23
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+## Rationale
+
+Movement uses account-based identity with 32-byte hexadecimal addresses.
+
+Each Movement account address:
+
+- Is globally unique within a Movement network
+- Is used directly in transaction operations
+- Is derived from the account's authentication key at creation
+- Is represented as a hex string with a `0x` prefix
+
+Because Movement addresses are stable identifiers and tied to a specific chain via `chain_id`, they are suitable for CAIP-10 account identifiers.
+
+## Specification
+
+A Movement [CAIP-10][] account identifier MUST follow:
+
+`movement:<reference>:<address>`
+
+Where:
+
+- `movement` is the namespace
+- `<reference>` is defined by the Movement [CAIP-2 Profile][]
+- `<address>` is a valid Movement account address
+
+### Address Format
+
+Movement account addresses MUST:
+
+- Begin with `0x`
+- Be followed by 1 to 64 hexadecimal characters (`0-9`, `a-f`, `A-F`)
+- Represent a 32-byte (256-bit) value
+- Be case-insensitive
+
+The canonical form is the full zero-padded 66-character representation (`0x` + 64 hex characters). Shortened forms that omit leading zeros (e.g., `0x1`) are valid but SHOULD be expanded to the full form for CAIP-10 identifiers.
+
+Regex:
+
+```
+^0x[0-9a-fA-F]{1,64}$
+```
+
+### Resolution
+
+To validate a Movement CAIP-10 identifier:
+
+1. Parse the namespace (`movement`).
+2. Validate the CAIP-2 reference according to the Movement [CAIP-2 Profile][].
+3. Validate the address against the address format rules above.
+4. Query a Movement REST API endpoint to confirm account existence.
+
+Account existence may be verified via the [REST API][]:
+
+#### Example Request
+
+```bash
+curl https://mainnet.movementnetwork.xyz/v1/accounts/0x1
+```
+
+#### Example Response
+
+```jsonc
+{
+  "sequence_number": "0",
+  "authentication_key": "0x0000000000000000000000000000000000000000000000000000000000000001"
+}
+```
+
+The API returns account data for any valid address format. An account with
+`sequence_number` of `"0"` and no on-chain resources may not have been
+explicitly created yet.
+
+## Examples
+
+### Movement Mainnet
+
+```
+movement:126:0x0000000000000000000000000000000000000000000000000000000000000001
+movement:126:0x1
+movement:126:0xd5fb7899ac1e3b4a51bfbf0dcafaa78453bb8e9a64a93a8e47fedad6b8c48171
+```
+
+### Movement Testnet
+
+```
+movement:250:0x0000000000000000000000000000000000000000000000000000000000000001
+movement:250:0x1
+```
+
+## Security Considerations
+
+Movement addresses are hexadecimal strings and may be subject to phishing using visually similar addresses.
+
+Applications SHOULD:
+
+- Validate account existence before processing transactions
+- Display full CAIP-10 identifiers when clarity is required
+- Expand shortened addresses to their full zero-padded form for comparison
+
+## Test Cases
+
+Valid:
+
+```
+movement:126:0x0000000000000000000000000000000000000000000000000000000000000001
+movement:126:0x1
+movement:126:0xd5fb7899ac1e3b4a51bfbf0dcafaa78453bb8e9a64a93a8e47fedad6b8c48171
+movement:250:0x1
+```
+
+Invalid:
+
+```
+movement:126:0x
+movement:126:0xGHIJKL
+movement:126:1
+movement:126:0x0000000000000000000000000000000000000000000000000000000000000000000001
+```
+
+## References
+
+- [REST API][] - Movement REST API for account lookups
+- [CAIP-2 Profile][] - Movement chain identification
+
+[CAIP-2 Profile]: ./caip2.md
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[REST API]: https://mainnet.movementnetwork.xyz/v1
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/movement/caip2.md
+++ b/movement/caip2.md
@@ -1,0 +1,116 @@
+---
+namespace-identifier: movement-caip2
+title: Movement Namespace - Chains
+author: Andy Golay (@andygolay)
+discussions-to:
+status: Draft
+type: Standard
+created: 2026-03-23
+updated: 2026-03-23
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Rationale
+
+In CAIP-2 a general blockchain identification scheme is defined. This is the
+implementation of CAIP-2 for Movement. Blockchains in the "movement" namespace are
+identified by their numeric `chain_id`, assigned at genesis. Each network is
+maintained by a set of validators with its own REST API endpoints. These chain
+IDs require no transformations to be used as conformant CAIP-2 references.
+
+## Syntax
+
+The namespace "movement" refers to the Movement Network blockchain platform.
+
+### Reference Definition
+
+The definition for this namespace will use the `chain_id` as an identifier
+for different Movement chains. The chain ID is a positive integer assigned at
+genesis:
+
+| Network | Chain ID |
+|---------|----------|
+| Mainnet | 126      |
+| Testnet | 250      |
+
+### Resolution Method
+
+To resolve a blockchain reference for the Movement namespace, make an HTTP GET
+request to the [REST API][] of a fullnode, for example:
+
+```bash
+# Mainnet
+curl https://mainnet.movementnetwork.xyz/v1
+
+# Testnet
+curl https://testnet.movementnetwork.xyz/v1
+```
+
+```jsonc
+// Mainnet Response
+{
+  "chain_id": 126,
+  "epoch": "10777734",
+  "ledger_version": "101649253",
+  "oldest_ledger_version": "0",
+  "ledger_timestamp": "1774318053802368",
+  "node_role": "full_node",
+  "oldest_block_height": "0",
+  "block_height": "40497312",
+  "git_hash": "f24a5bc"
+}
+```
+
+```jsonc
+// Testnet Response
+{
+  "chain_id": 250,
+  "epoch": "...",
+  "ledger_version": "...",
+  "oldest_ledger_version": "0",
+  "ledger_timestamp": "...",
+  "node_role": "full_node",
+  "oldest_block_height": "0",
+  "block_height": "...",
+  "git_hash": "..."
+}
+```
+
+The response will return `chain_id` as an integer that can be used directly
+as the CAIP-2 reference.
+
+### Backwards Compatibility
+
+Not applicable
+
+## Test Cases
+
+This is a list of manually composed examples
+
+```bash
+# Movement Mainnet
+movement:126
+
+# Movement Testnet
+movement:250
+
+```
+
+## References
+
+- [REST API][] - REST API reference for Movement Network
+- [Networks][] - Movement network information and endpoints
+- [Explorer][] - Movement block explorer
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[REST API]: https://mainnet.movementnetwork.xyz/v1
+[Networks]: https://docs.movementnetwork.xyz/
+[Explorer]: https://explorer.movementnetwork.xyz/
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/movement/caip2.md
+++ b/movement/caip2.md
@@ -16,7 +16,7 @@ requires: CAIP-2
 
 ## Rationale
 
-In CAIP-2 a general blockchain identification scheme is defined. This is the
+In [CAIP-2][] a general blockchain identification scheme is defined. This is the
 implementation of CAIP-2 for Movement. Blockchains in the "movement" namespace are
 identified by their numeric `chain_id`, assigned at genesis. Each network is
 maintained by a set of validators with its own REST API endpoints. These chain
@@ -29,8 +29,9 @@ The namespace "movement" refers to the Movement Network blockchain platform.
 ### Reference Definition
 
 The definition for this namespace will use the `chain_id` as an identifier
-for different Movement chains. The chain ID is a positive integer assigned at
-genesis:
+for different Movement chains. The chain ID is a positive integer (greater than
+0 with no maximum value) assigned in the genesis configuration. Each network's
+chain ID is set by the validators at genesis and is immutable thereafter:
 
 | Network | Chain ID |
 |---------|----------|
@@ -40,7 +41,8 @@ genesis:
 ### Resolution Method
 
 To resolve a blockchain reference for the Movement namespace, make an HTTP GET
-request to the [REST API][] of a fullnode, for example:
+request to the [REST API][] of a fullnode. The REST API endpoints are stable,
+long-lived URLs. For example:
 
 ```bash
 # Mainnet

--- a/movement/caip2.md
+++ b/movement/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: movement-caip2
 title: Movement Namespace - Chains
 author: Andy Golay (@andygolay)
-discussions-to:
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/179
 status: Draft
 type: Standard
 created: 2026-03-23


### PR DESCRIPTION
## Add Movement namespace

This PR introduces the Movement namespace to the ChainAgnostic namespaces registry.

### Added Files

- `movement/README.md` - Namespace profile for Movement Network
- `movement/caip2.md` - CAIP-2 chain identification specification for Movement
- `movement/caip10.md` - CAIP-10 account identification specification for Movement

### Summary

Movement is a Layer 2 network built on Move, featuring parallel execution for high throughput. This PR establishes the `movement` namespace for identifying Movement-based chains and accounts.

### Chain Identification (CAIP-2)

Chains in the Movement namespace are identified by their numeric `chain_id`, which is assigned at genesis and requires no transformation to be used as a CAIP-2 reference.

| Network | Chain ID | CAIP-2 Identifier |
|---------|----------|--------------------|
| Mainnet | 126 | `movement:126` |
| Testnet | 250 | `movement:250` |

### Account Identification (CAIP-10)

Movement accounts are identified by 32-byte hexadecimal addresses with a `0x` prefix. Account identifiers follow the format `movement:<chain_id>:<address>`.

Example: `movement:126:0xd5fb7899ac1e3b4a51bfbf0dcafaa78453bb8e9a64a93a8e47fedad6b8c48171`

### Resolution

Chain IDs can be resolved by querying the REST API of any Movement fullnode:

```
curl https://mainnet.movementnetwork.xyz/v1
```

The `chain_id` field in the response provides the identifier.

Account existence can be verified via:

```
curl https://mainnet.movementnetwork.xyz/v1/accounts/<address>
```

### References

- [Movement Documentation](https://docs.movementnetwork.xyz/)
- [Movement GitHub Org](https://github.com/moveindustries)
- [Movement REST API](https://mainnet.movementnetwork.xyz/v1)
- [Movement Network Website](https://movementnetwork.xyz/)
- [Movement Explorer](https://explorer.movementnetwork.xyz/)
