### PR TITLE
Add tenzro namespace (CAIP-2/10/19/25)

### DIFF
--- a/tenzro/README.md
+++ b/tenzro/README.md
@@ -1,0 +1,43 @@
+---
+namespace-identifier: tenzro
+title: Tenzro Ecosystem
+author: Tenzro Engineering (eng@tenzro.com)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+status: Draft
+type: Informational
+created: 2026-05-02
+updated: 2026-05-02
+---
+
+# Namespace for Tenzro chains
+
+## Introduction
+
+Blockchains in the "tenzro" namespace are validated by their genesis block hash.
+Tenzro is an L1 settlement layer designed for AI-age applications: each chain in
+the namespace runs HotStuff-2 BFT consensus over a multi-VM execution layer
+(EVM, SVM, and Canton/DAML) with a single shared native balance per asset (the
+Sei-V2-style pointer model). The namespace covers all networks operated under
+this protocol regardless of which VM façade a wallet or dApp interacts with.
+
+## Syntax
+
+The namespace "tenzro" refers to the Tenzro Network protocol — see the
+project repository at <https://github.com/tenzro/tenzro-network> and the
+whitepaper at <https://tenzro.com>. Implementations of this namespace expose
+both an EVM-compatible JSON-RPC surface (`eth_*`, `chain_id` integer) and a
+Tenzro-native namespace (`tenzro_*`, including multi-VM scope methods).
+
+## References
+
+- [Tenzro Network repository][repo]
+- [HotStuff-2 BFT][hs2] — consensus algorithm
+- [Sei V2 pointer model][sei2] — basis for Tenzro's multi-VM token architecture
+
+[repo]: https://github.com/tenzro/tenzro-network
+[hs2]: https://eprint.iacr.org/2023/397.pdf
+[sei2]: https://blog.sei.io/sei-v2-the-first-parallelized-evm/
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tenzro/README.md
+++ b/tenzro/README.md
@@ -28,6 +28,26 @@ whitepaper at <https://tenzro.com>. Implementations of this namespace expose
 both an EVM-compatible JSON-RPC surface (`eth_*`, `chain_id` integer) and a
 Tenzro-native namespace (`tenzro_*`, including multi-VM scope methods).
 
+## Multi-VM façades
+
+A single Tenzro chain (one `tenzro:<reference>` identifier) hosts three
+execution-layer façades over a shared state:
+
+- **EVM** — reachable via `eth_*` JSON-RPC; the integer `chain_id` returned
+  by `eth_chainId` is exposed for compatibility with EVM tooling but is
+  **not** a separate CAIP-2 reference.
+- **SVM** — Solana VM bytecode runs natively. SPL Token instructions are
+  mapped to the Tenzro native token registry; SPL amounts are 9-decimal
+  values that get truncated to match the underlying token's stored
+  precision.
+- **Canton/DAML** — DAML 3.x contracts execute against the same shared
+  state; CIP-56 holdings are first-class.
+
+Each façade reads and writes the same balances and storage. SVM and Canton
+account references therefore resolve under `tenzro:`, not under `solana:`
+or any Canton-specific namespace; the underlying chain is identified by
+its Tenzro genesis hash regardless of which façade a caller uses.
+
 ## References
 
 - [Tenzro Network repository][repo]

--- a/tenzro/README.md
+++ b/tenzro/README.md
@@ -2,7 +2,7 @@
 namespace-identifier: tenzro
 title: Tenzro Ecosystem
 author: Tenzro Engineering (eng@tenzro.com)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
 status: Draft
 type: Informational
 created: 2026-05-02

--- a/tenzro/caip10.md
+++ b/tenzro/caip10.md
@@ -1,0 +1,81 @@
+---
+namespace-identifier: tenzro-caip10
+title: Tenzro Namespace - Addresses
+author: Tenzro Engineering (eng@tenzro.com)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+status: Draft
+type: Standard
+created: 2026-05-02
+updated: 2026-05-02
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+_For context, see the [CAIP-10][] specification._
+
+## Rationale
+
+A Tenzro address is a 32-byte identifier shared across the EVM, SVM, and
+Canton/DAML VM façades — there is one address per account, and the same
+underlying balance is visible through all three VMs (the pointer model).
+
+Two textual encodings are accepted, mirroring the two ecosystems Tenzro
+interoperates with most directly:
+
+- **Hex (EIP-55-style)**: `0x` followed by 64 lowercase hexadecimal
+  characters. Used by EVM-aware tooling and the `eth_*` JSON-RPC surface.
+- **Base58btc**: 32-byte address encoded with the Bitcoin/Solana
+  Base58btc alphabet (44 characters for a full 32-byte input). Used by
+  SVM-aware tooling and the Wallet Standard surface.
+
+CAIP-10 references for Tenzro accounts SHOULD use the **hex** form for
+parity with EVM tooling and CAIP-122 (SIWx) signatures. Implementations
+MUST accept either form on input and SHOULD normalize to lowercase hex
+on storage and display.
+
+## Syntax
+
+A Tenzro CAIP-10 account identifier matches:
+
+```
+account_id := chain_id ":" account_address
+account_address := hex_address | base58_address
+hex_address := "0x" [0-9a-f]{64}
+base58_address := [1-9A-HJ-NP-Za-km-z]{43,44}
+```
+
+where `chain_id` is the CAIP-2 identifier defined in `caip2.md`.
+
+## Chain IDs
+
+_For context, see the [CAIP-2][] specification and `caip2.md`._
+
+| Network Name | Chain ID                             |
+| ------------ | ------------------------------------ |
+| Testnet      | tenzro:92bd27db9713293097f0e63476e3911e |
+| Mainnet      | TBD                                  |
+
+## Test Cases
+
+```
+# Tenzro Testnet — hex form (canonical)
+tenzro:92bd27db9713293097f0e63476e3911e:0x0000000000000000000000000000000000000000000000000000000000000000
+
+# Tenzro Testnet — base58 form (also accepted)
+tenzro:92bd27db9713293097f0e63476e3911e:11111111111111111111111111111111
+```
+
+## References
+
+- [CAIP-2][]
+- [CAIP-10][]
+- [Tenzro Network repository][repo]
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[repo]: https://github.com/tenzro/tenzro-network
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/tenzro/caip10.md
+++ b/tenzro/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: tenzro-caip10
 title: Tenzro Namespace - Addresses
 author: Tenzro Engineering (eng@tenzro.com)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
 status: Draft
 type: Standard
 created: 2026-05-02

--- a/tenzro/caip122.md
+++ b/tenzro/caip122.md
@@ -1,0 +1,91 @@
+---
+namespace-identifier: tenzro-caip122
+title: Tenzro Namespace - SIWx
+author: Hilal Agil (@hilarl)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
+status: Draft
+type: Standard
+created: 2026-05-02
+updated: 2026-05-02
+requires: ["CAIP-122", "CAIP-2", "CAIP-10"]
+---
+
+## CAIP-122
+
+For context, see the [CAIP-122](CAIP-122) specification.
+
+## Rationale
+
+Tenzro uses Ed25519 as its native signing algorithm (the same key material backs validator signing, TDIP DIDs, and account-level signing). This specification names the signature type, fixes the message-byte form, and describes verification as required by [CAIP-122](CAIP-122).
+
+## Specification
+
+### Signing Algorithm
+
+Tenzro uses [Ed25519] for signing and verifying messages. Tenzro account public keys are 32-byte Ed25519 public keys, encoded for display either as a `0x`-prefixed lowercase hex string (canonical form) or as a base58btc string.
+
+### Signature Type
+
+We propose the signature type `tenzro:ed25519` to refer to the chain and algorithm uniquely.
+
+### Signature Creation
+
+The abstract data model from CAIP-122 must be converted to an unambiguous string representation, and that string is then encoded as UTF-8 bytes to be signed over.
+
+We adopt the same human-readable layout as [EIP-4361] / Solana's CAIP-122 profile to keep wallet UX uniform across namespaces:
+
+```
+${domain} wants you to sign in with your Tenzro account:
+${address}
+
+${statement}
+
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Nonce: ${nonce}
+Issued At: ${issued-at}
+Expiration Time: ${expiration-time}
+Not Before: ${not-before}
+Request ID: ${request-id}
+Resources:
+- ${resources[0]}
+- ${resources[1]}
+...
+- ${resources[n]}
+```
+
+`${address}` is the Tenzro account in canonical hex form (`0x` + 64 lowercase hex chars).
+`${chain-id}` is the CAIP-2 reference for the target Tenzro network (see `caip2.md` in this namespace; e.g. `92bd27db9713293097f0e63476e3911e` for testnet).
+
+Example:
+
+```
+service.org wants you to sign in with your Tenzro account:
+0x4d7e1c3f5a8b2e9d0c7f3a1b6e9d4c8f2a5b7e0d3c6f9a2b5e8d1c4f7a0b3e6d
+
+I accept the ServiceOrg Terms of Service: https://service.org/tos
+
+URI: https://service.org/login
+Version: 1
+Chain ID: 92bd27db9713293097f0e63476e3911e
+Nonce: 32891757
+Issued At: 2026-05-02T16:25:24.000Z
+```
+
+The signing input is the UTF-8 byte representation of the string above, signed directly with Ed25519 (no additional pre-hashing — Ed25519 internally hashes the message with SHA-512 per RFC 8032).
+
+### Signature Verification
+
+Verification is standard Ed25519 verification (RFC 8032) over the UTF-8 bytes of the message string. The verification key is the 32-byte Ed25519 public key derived from the displayed address: when the address is in canonical hex form, the public key bytes are exactly the 32 bytes after the `0x` prefix.
+
+Implementations MUST reject low-order public keys and non-canonical scalar encodings, consistent with RFC 8032 §5.1.7 strict-verification rules.
+
+## References
+
+- [EIP-4361]: https://eips.ethereum.org/EIPS/eip-4361
+- [CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
+- [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
+- [CAIP-122]: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-122.md
+- [Ed25519]: https://ed25519.cr.yp.to/
+- [RFC 8032]: https://datatracker.ietf.org/doc/html/rfc8032

--- a/tenzro/caip19.md
+++ b/tenzro/caip19.md
@@ -2,7 +2,7 @@
 namespace-identifier: tenzro-caip19
 title: Tenzro Namespace - Asset
 author: Tenzro Engineering (eng@tenzro.com)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
 status: Draft
 type: Standard
 created: 2026-05-02

--- a/tenzro/caip19.md
+++ b/tenzro/caip19.md
@@ -33,10 +33,11 @@ Two asset namespaces are defined:
 | `token`           | Fungible token registered in Tenzro's unified token registry, identified by 32-byte token ID |
 | `nft`             | Non-fungible token, identified by `<collection_id>/<token_id>` where `collection_id` is the 32-byte collection ID |
 
-The native TNZO coin SHOULD use the `slip44` namespace once a SLIP-44 index
-is registered upstream. Until then, implementations MAY use the literal
-reference `tenzro` under `slip44` (vendor-prefixed pre-registration); see
-the SLIP-44 PR tracker for the registered index.
+The native TNZO coin uses SLIP-44 coin type **`1414421071`**
+(`0xd44e5a4f`), registered via [satoshilabs/slips#2015][slip44-pr]. Until
+that PR is merged, implementations MAY also accept the literal reference
+`tenzro` under `slip44` (vendor-prefixed pre-registration form) for
+forward compatibility.
 
 ## Syntax
 
@@ -50,8 +51,9 @@ asset_id := chain_id "/" asset_namespace ":" asset_reference [ "/" token_id ]
 - `chain_id`: CAIP-2 identifier (see `caip2.md`)
 - `asset_namespace`: `slip44` | `token` | `nft`
 - `asset_reference`:
-  - For `slip44`: registered SLIP-44 coin index (decimal integer) or the
-    pre-registration string `tenzro`
+  - For `slip44`: SLIP-44 coin index `1414421071` (decimal); the
+    pre-registration string `tenzro` MAY also be accepted on input
+    until the upstream PR merges
   - For `token`: 64-character lowercase hex of the 32-byte token ID
   - For `nft`: 64-character lowercase hex of the 32-byte collection ID
 - `token_id` (NFT only): 64-character lowercase hex of the 32-byte
@@ -61,7 +63,10 @@ asset_id := chain_id "/" asset_namespace ":" asset_reference [ "/" token_id ]
 ## Examples
 
 ```
-# Tenzro Testnet — native TNZO coin (pre-registration form)
+# Tenzro Testnet — native TNZO coin (registered SLIP-44 index)
+tenzro:92bd27db9713293097f0e63476e3911e/slip44:1414421071
+
+# Tenzro Testnet — native TNZO coin (pre-registration form, accepted until slips#2015 merges)
 tenzro:92bd27db9713293097f0e63476e3911e/slip44:tenzro
 
 # Tenzro Testnet — fungible token (e.g. an ERC-20 deployed via TOKEN_FACTORY)
@@ -99,6 +104,7 @@ canonical name; the per-VM contract addresses are aliases.
 [CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
 [CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
 [SLIP-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+[slip44-pr]: https://github.com/satoshilabs/slips/pull/2015
 [repo]: https://github.com/tenzro/tenzro-network
 
 ## Copyright

--- a/tenzro/caip19.md
+++ b/tenzro/caip19.md
@@ -1,0 +1,106 @@
+---
+namespace-identifier: tenzro-caip19
+title: Tenzro Namespace - Asset
+author: Tenzro Engineering (eng@tenzro.com)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+status: Draft
+type: Standard
+created: 2026-05-02
+updated: 2026-05-02
+requires: ["CAIP-2", "CAIP-10", "CAIP-19"]
+---
+
+# CAIP-19
+
+*For context, see the [CAIP-19][] specification.*
+
+## Rationale
+
+Tenzro hosts assets across three VM façades (EVM, SVM, Canton/DAML) that all
+share a single underlying native balance — the Sei-V2-style pointer model.
+For CAIP-19 purposes, an asset is identified by its canonical Tenzro token
+ID (a 32-byte SHA-256 of `creator || nonce`) regardless of which VM façade a
+client uses to interact with it. The same TNZO holding is reachable as wTNZO
+(ERC-20) on the EVM façade, as a wTNZO SPL token on the SVM façade, and as a
+CIP-56 holding on the Canton façade — but the CAIP-19 reference is one and
+the same.
+
+Two asset namespaces are defined:
+
+| `asset_namespace` | Meaning                                            |
+| :---------------- | :------------------------------------------------- |
+| `slip44`          | TNZO native coin — uses the [SLIP-44][] coin index |
+| `token`           | Fungible token registered in Tenzro's unified token registry, identified by 32-byte token ID |
+| `nft`             | Non-fungible token, identified by `<collection_id>/<token_id>` where `collection_id` is the 32-byte collection ID |
+
+The native TNZO coin SHOULD use the `slip44` namespace once a SLIP-44 index
+is registered upstream. Until then, implementations MAY use the literal
+reference `tenzro` under `slip44` (vendor-prefixed pre-registration); see
+the SLIP-44 PR tracker for the registered index.
+
+## Syntax
+
+After the [CAIP-2][] chain prefix, a slash defines an `asset_namespace` and
+an `asset_reference`:
+
+```
+asset_id := chain_id "/" asset_namespace ":" asset_reference [ "/" token_id ]
+```
+
+- `chain_id`: CAIP-2 identifier (see `caip2.md`)
+- `asset_namespace`: `slip44` | `token` | `nft`
+- `asset_reference`:
+  - For `slip44`: registered SLIP-44 coin index (decimal integer) or the
+    pre-registration string `tenzro`
+  - For `token`: 64-character lowercase hex of the 32-byte token ID
+  - For `nft`: 64-character lowercase hex of the 32-byte collection ID
+- `token_id` (NFT only): 64-character lowercase hex of the 32-byte
+  `mintRandom`-derived token ID, or a decimal integer for sequentially
+  minted tokens
+
+## Examples
+
+```
+# Tenzro Testnet — native TNZO coin (pre-registration form)
+tenzro:92bd27db9713293097f0e63476e3911e/slip44:tenzro
+
+# Tenzro Testnet — fungible token (e.g. an ERC-20 deployed via TOKEN_FACTORY)
+tenzro:92bd27db9713293097f0e63476e3911e/token:7a4bcb13a6b2b384c284b5caa6e5ef3126527f93000000000000000000000000
+
+# Tenzro Testnet — NFT (collection_id / token_id)
+tenzro:92bd27db9713293097f0e63476e3911e/nft:a1b2c3d4e5f6...64hex.../42
+```
+
+## Cross-VM identity
+
+The same asset identifier MUST resolve to the same underlying balance
+regardless of which VM façade a client queries. For example, given a TNZO
+balance for an account `A`:
+
+- `eth_getBalance(A)` on the EVM façade
+- `tenzro_getTokenBalance({owner: A, token: <wtnzo_evm_addr>})` on the
+  Tenzro-native API
+- An SPL token-account query against the SVM `tenzro_cross_vm` program for
+  wTNZO
+
+…all return the same numeric value (in 18-decimal precision; SPL truncates
+to 9 decimals at the boundary). The CAIP-19 identifier is the cross-VM
+canonical name; the per-VM contract addresses are aliases.
+
+## References
+
+- [CAIP-2][]
+- [CAIP-10][]
+- [CAIP-19][]
+- [SLIP-44][]
+- [Tenzro Network repository][repo]
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[SLIP-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+[repo]: https://github.com/tenzro/tenzro-network
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tenzro/caip2.md
+++ b/tenzro/caip2.md
@@ -1,0 +1,108 @@
+---
+namespace-identifier: tenzro-caip2
+title: Tenzro Namespace - Chains
+author: Tenzro Engineering (eng@tenzro.com)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+status: Draft
+type: Standard
+created: 2026-05-02
+updated: 2026-05-02
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Rationale
+
+In CAIP-2 a general blockchain identification scheme is defined. This is the
+implementation of CAIP-2 for Tenzro. Blockchains in the "tenzro" namespace are
+validated by their genesis block hash; each chain runs an independent
+HotStuff-2 BFT consensus instance with its own genesis block and validator
+set. Genesis hashes are 32-byte SHA-256 digests of the canonical genesis
+block; their first 32 hex characters are used as the CAIP-2 reference.
+
+## Syntax
+
+The namespace "tenzro" refers to the Tenzro Network protocol.
+
+### Reference Definition
+
+The CAIP-2 reference for a Tenzro chain is the lowercase hexadecimal
+encoding of the first 16 bytes (32 hex characters) of the genesis block
+hash:
+
+```
+chain_id := "tenzro:" + lowercase(hex(genesis_hash[0..16]))
+```
+
+This conforms to CAIP-2's reference grammar `[-a-zA-Z0-9]{1,32}`.
+
+### Resolution Method
+
+To resolve a Tenzro chain reference, make a JSON-RPC request to the chain's
+RPC endpoint with method `tenzro_getBlock` and the genesis block height
+(`block_number: 0`):
+
+```jsonc
+// Request
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "tenzro_getBlock",
+  "params": [{ "block_number": 0 }]
+}
+
+// Response (truncated to relevant fields)
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "hash": "92bd27db9713293097f0e63476e3911e77b706c1b20f4a5e97d44fe7a8d51648",
+    "header": {
+      "height": 0,
+      "chain_id": 1337
+    }
+  }
+}
+```
+
+The `hash` field is a 64-character lowercase hex string (32 bytes).
+Truncate it to the first 32 characters to obtain the CAIP-2 reference.
+
+EVM-compatible callers may also use `eth_chainId` to retrieve the
+integer chain ID, but that integer is **not** the CAIP-2 reference —
+the canonical reference always uses the truncated genesis hash.
+
+### Backwards Compatibility
+
+Not applicable. Tenzro is a fresh L1 with no prior CAIP-2 registration.
+
+## Test Cases
+
+```
+# Tenzro Testnet
+#   genesis hash: 92bd27db9713293097f0e63476e3911e77b706c1b20f4a5e97d44fe7a8d51648
+#   integer chain_id (EVM-compat): 1337
+tenzro:92bd27db9713293097f0e63476e3911e
+
+# Tenzro Mainnet (TBD — populated at mainnet launch)
+tenzro:<genesis_hash[0..16] in lowercase hex>
+```
+
+Until mainnet is launched, only the testnet reference above is canonical.
+
+## References
+
+- [CAIP-2][]
+- [Tenzro Network repository][repo]
+- [HotStuff-2 BFT][hs2]
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[repo]: https://github.com/tenzro/tenzro-network
+[hs2]: https://eprint.iacr.org/2023/397.pdf
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tenzro/caip2.md
+++ b/tenzro/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: tenzro-caip2
 title: Tenzro Namespace - Chains
 author: Tenzro Engineering (eng@tenzro.com)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
 status: Draft
 type: Standard
 created: 2026-05-02

--- a/tenzro/caip25.md
+++ b/tenzro/caip25.md
@@ -2,7 +2,7 @@
 namespace-identifier: tenzro-caip25
 title: Tenzro Namespace - JSON-RPC Provider Authorization
 author: Tenzro Engineering (eng@tenzro.com)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/184
 status: Draft
 type: Standard
 created: 2026-05-02

--- a/tenzro/caip25.md
+++ b/tenzro/caip25.md
@@ -1,0 +1,189 @@
+---
+namespace-identifier: tenzro-caip25
+title: Tenzro Namespace - JSON-RPC Provider Authorization
+author: Tenzro Engineering (eng@tenzro.com)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/TBD
+status: Draft
+type: Standard
+created: 2026-05-02
+updated: 2026-05-02
+requires: ["CAIP-2", "CAIP-25", "CAIP-217"]
+---
+
+# CAIP-25
+
+_For context, see the [CAIP-25][] specification._
+
+## Rationale
+
+A Tenzro chain runs three VM façades over a single shared native balance
+(EVM, SVM, and Canton/DAML — the Sei-V2-style pointer model). A provider
+authorization session against a Tenzro node therefore needs to express
+capabilities for **multiple method namespaces routed to the same chain**
+rather than for distinct chains. Tenzro reuses [CAIP-25] / [CAIP-217]
+for this without inventing new framing: a single Tenzro `chain_id` may
+appear under one [CAIP-217] scope object whose `methods` array spans
+`eth_*`, `tenzro_*`, and a constrained subset of `solana_*` methods.
+
+This is consistent with how the Tenzro browser extension and SDK
+(`network.tenzro.wallet`) authorize sessions today: one scope per chain,
+multiple method families within the scope, and the dApp routes calls by
+method-name prefix. See "Routing rules" below for the normative routing
+that consumers of a Tenzro CAIP-25 session MUST follow.
+
+## Network-Specific versus Namespace-Wide Scopes
+
+Tenzro authorization scopes are **always network-specific** —
+`tenzro:<chain_id>` rather than the bare namespace `tenzro`. Each
+Tenzro chain has an independent HotStuff-2 BFT validator set and its
+own genesis hash; capabilities and account permissions do not transfer
+across chains. Implementations MUST NOT use a namespace-wide
+`tenzro` scope.
+
+## Multichain Considerations
+
+Tenzro sessions commonly span both a Tenzro chain and external chains
+(e.g. a wallet user authorizing a dApp to interact with both
+`tenzro:92bd27db9713293097f0e63476e3911e` and `eip155:1`). In that
+case implementers SHOULD use distinct [CAIP-217] authorization
+objects per chain — the Tenzro scope for Tenzro-routed methods, and a
+separate `eip155:N` scope for direct Ethereum interactions.
+
+The Tenzro injected provider (`window.tenzro`, EIP-6963 `rdns =
+network.tenzro.wallet`) speaks [EIP-1193] for its EVM façade and
+exposes `tenzro_*` and a constrained `solana_*` subset over the same
+session. Hosts MAY also expose a parallel `window.solana` Wallet
+Standard surface bound to the same underlying account; in that case
+the same Tenzro `chain_id` scope authorizes both surfaces.
+
+## Routing rules
+
+Within a Tenzro scope, the provider routes inbound calls by method-name
+prefix. Implementations MUST observe the following routing — these
+rules match the Tenzro reference extension's `resolveMethodName`
+dispatcher and the node's actual RPC surface.
+
+| Method prefix              | Routed to                                        | Notes |
+| :------------------------- | :----------------------------------------------- | :---- |
+| `eth_*`, `personal_*`, `wallet_*` | EVM façade JSON-RPC on the node           | Standard EIP-1193 surface |
+| `tenzro_*`                 | Native Tenzro RPC namespace                      | Multi-VM scope methods, identity, payments, agents, multi-modal AI |
+| `solana_signTransaction`, `solana_signAndSendTransaction`, `solana_signMessage`, `solana_signIn` | Wallet-side signers (SVM façade transactions) | Pass-through; signed and submitted via the SVM transaction path |
+| `solana_*` reads (`getBalance`, `getTokenAccountsByOwner`, etc.) | **Rejected** — re-route to `tenzro_*` equivalents | Tenzro does NOT implement the Solana JSON-RPC read surface; use `tenzro_listTokens` / `tenzro_getTokenBalance` / `tenzro_crossVmTransfer` |
+
+A request for an unsupported method within the scope MUST return
+JSON-RPC error code `-32601` (`Method not found`) with a message
+identifying the offending method and the routing rule that rejected it.
+
+## Setting Environmental Variables to pass via scopedProperties
+
+Tenzro scopes SHOULD declare per-scope capabilities in
+`scopedProperties`. The following keys are defined by this namespace:
+
+| `scopedProperties` key | Type                              | Meaning |
+| :---                   | :---                              | :--- |
+| `vmFacades`            | array of `"evm" \| "svm" \| "canton"` | Subset of VM façades the wallet will route for in this session. Default: `["evm", "svm"]`. |
+| `dpopBound`            | boolean                           | Whether per-call DPoP-bound auth ([RFC 9449][]) is required. Tenzro extension sessions default to `true`. |
+| `nativeAssetCaip19`    | string ([CAIP-19][])              | The CAIP-19 identifier for the native asset (TNZO) on this chain — informational, useful for fee display. |
+| `evmChainId`           | integer                           | The EIP-155 integer `chainId` (`eth_chainId`) corresponding to this Tenzro chain — clients use this to fill the `eth_chainId` field of EVM transactions without a separate round-trip. |
+
+Implementers are RECOMMENDED to declare `evmChainId` whenever the EVM
+façade is included in `vmFacades`, since EVM tooling needs the
+integer chain ID and it cannot be derived from the truncated genesis
+hash.
+
+## Examples
+
+Example CAIP-25 Request
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "provider_authorize",
+  "params": {
+    "sessionScopes": {
+      "tenzro:92bd27db9713293097f0e63476e3911e": {
+        "methods": [
+          "eth_chainId",
+          "eth_blockNumber",
+          "eth_getBalance",
+          "eth_sendTransaction",
+          "personal_sign",
+          "tenzro_listTokens",
+          "tenzro_getTokenBalance",
+          "tenzro_crossVmTransfer",
+          "solana_signTransaction",
+          "solana_signMessage"
+        ],
+        "notifications": ["accountsChanged", "chainChanged"],
+        "accounts": [
+          "tenzro:92bd27db9713293097f0e63476e3911e:0x0000000000000000000000000000000000000000000000000000000000000000"
+        ]
+      }
+    }
+  }
+}
+```
+
+Example CAIP-25 Response
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "sessionScopes": {
+      "tenzro:92bd27db9713293097f0e63476e3911e": {
+        "methods": [
+          "eth_chainId",
+          "eth_blockNumber",
+          "eth_getBalance",
+          "eth_sendTransaction",
+          "personal_sign",
+          "tenzro_listTokens",
+          "tenzro_getTokenBalance",
+          "tenzro_crossVmTransfer",
+          "solana_signTransaction",
+          "solana_signMessage"
+        ],
+        "notifications": ["accountsChanged", "chainChanged"],
+        "accounts": [
+          "tenzro:92bd27db9713293097f0e63476e3911e:0x0000000000000000000000000000000000000000000000000000000000000000"
+        ]
+      }
+    },
+    "scopedProperties": {
+      "tenzro:92bd27db9713293097f0e63476e3911e": {
+        "vmFacades": ["evm", "svm"],
+        "dpopBound": true,
+        "evmChainId": 1337,
+        "nativeAssetCaip19": "tenzro:92bd27db9713293097f0e63476e3911e/slip44:tenzro"
+      }
+    }
+  }
+}
+```
+
+## References
+
+- [CAIP-2][]
+- [CAIP-19][]
+- [CAIP-25][]
+- [CAIP-217][]
+- [EIP-1193][]
+- [EIP-6963][]
+- [RFC 9449][] — DPoP
+- [Tenzro Network repository][repo]
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[CAIP-25]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-25.md
+[CAIP-217]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-217.md
+[EIP-1193]: https://eips.ethereum.org/EIPS/eip-1193
+[EIP-6963]: https://eips.ethereum.org/EIPS/eip-6963
+[RFC 9449]: https://www.rfc-editor.org/rfc/rfc9449
+[repo]: https://github.com/tenzro/tenzro-network
+
+## Rights
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

Adds the `tenzro` namespace covering Tenzro Network — an L1 settlement layer with HotStuff-2 BFT consensus over a multi-VM execution layer (EVM + SVM + Canton/DAML) sharing a single native balance per asset (Sei-V2-style pointer model).

## CAIPs covered

- **CAIP-2** — chain ID is the lowercase hex of the first 16 bytes of the genesis block hash (e.g. `tenzro:92bd27db9713293097f0e63476e3911e` for testnet).
- **CAIP-10** — 32-byte addresses, hex (`0x` + 64 chars) canonical with base58btc accepted on input.
- **CAIP-19** — `slip44` (native TNZO), `token` (32-byte token IDs from the unified registry), and `nft` (32-byte collection ID + token ID). Same identifier resolves to the same balance across all three VM façades.
- **CAIP-25** — multi-VM provider authorization, one scope per chain with `eth_*` / `tenzro_*` / `solana_sign*` methods and `scopedProperties` for `vmFacades`, `dpopBound`, `evmChainId`, `nativeAssetCaip19`.

## Notes

- Mainnet CAIP-2 reference will be added in a follow-up PR at mainnet launch.
- A SLIP-44 coin index PR is being filed in parallel against `satoshilabs/slips`. Until merged, the `slip44` reference uses the pre-registration string `tenzro`.
- Repo: https://github.com/tenzro/tenzro-network
