### PR TITLE
Add klv namespace for the Klever Blockchain

### DIFF
--- a/klv/README.md
+++ b/klv/README.md
@@ -1,0 +1,54 @@
+---
+namespace-identifier: klv
+title: Klever Namespace
+author: Nicollas Gabriel da Silva (@nickgs1337)
+discussions-to: https://forum.klever.org/, https://github.com/klever-io/klever-go/discussions
+status: Draft
+type: Informational
+created: 2026-05-13
+---
+
+# Namespace for Klever Blockchains
+
+This document defines the applicability of CAIP schemes to the networks of the
+Klever blockchain ecosystem. Klever is a layer-1 proof-of-stake blockchain
+with ed25519 keys, Bech32 addresses prefixed `klv1...`, Wasmer-based smart
+contracts, and a native multi-asset model (KDA — Klever Digital Asset) that
+supports fungible tokens, NFTs, and SFTs as first-class on-chain primitives.
+
+## Syntax
+
+The namespace `klv` refers to the open-source Klever blockchain protocol and
+its production, testing, and development networks.
+
+## References
+
+- [Klever][] — Klever's main website and ecosystem hub.
+- [KleverChain explorer][kleverscan] — Public block explorer for Klever
+  mainnet, testnet, and devnet.
+- [Klever node REST API][klever-api] — Public REST endpoint to fetch chain
+  identity, account state, and asset metadata.
+- [Klever Connect SDK][klever-connect] — Official TypeScript SDK that
+  implements the Klever transaction format, signing flow, and Bech32 address
+  encoding.
+- [klever-go node source][klever-go] — Reference Go implementation of the
+  Klever node, including the address converter, transaction processing, and
+  KDA built-in functions.
+- [SLIP-44][] — The registry of canonical coin types for derivation paths.
+  Klever is registered as coin type `690` (`KLV`, `KleverChain`).
+- [BIP_0173][] — The Bech32 specification used for Klever addresses.
+
+[Klever]: https://klever.org
+[kleverscan]: https://kleverscan.org
+[klever-api]: https://api.mainnet.klever.org/v1.0
+[klever-connect]: https://github.com/klever-io/klever-connect
+[klever-go]: https://github.com/klever-io/klever-go
+[SLIP-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+[BIP_0173]: https://en.bitcoin.it/wiki/BIP_0173
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+
+## Rights
+
+Copyright and related rights waived via CC0.

--- a/klv/README.md
+++ b/klv/README.md
@@ -14,7 +14,8 @@ This document defines the applicability of CAIP schemes to the networks of the
 Klever blockchain ecosystem. Klever is a layer-1 proof-of-stake blockchain
 with ed25519 keys, Bech32 addresses prefixed `klv1...`, Wasmer-based smart
 contracts, and a native multi-asset model (KDA — Klever Digital Asset) that
-supports fungible tokens, NFTs, and SFTs as first-class on-chain primitives.
+supports fungible tokens, non-fungible tokens (NFTs), and semi-fungible
+tokens (SFTs) as first-class on-chain primitives.
 
 ## Syntax
 

--- a/klv/caip10.md
+++ b/klv/caip10.md
@@ -1,0 +1,91 @@
+---
+namespace-identifier: klv-caip10
+title: Klever Namespace - Addresses
+author: Nicollas Gabriel da Silva (@nickgs1337)
+discussions-to: https://forum.klever.org/, https://github.com/klever-io/klever-go/discussions
+status: Draft
+type: Standard
+created: 2026-05-13
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+_For context, see the [CAIP-10][] specification._
+
+## Rationale
+
+The Klever address format is Bech32, specified by [BIP_0173][]. The
+human-readable-part is `klv` with the universal separator `1`, so every
+Klever address starts with `klv1`, e.g.:
+
+```
+klv1edd0ymfmv9r2mxk7mdtsk4zfeql5cp9vyn7t4y4adq58vp2r9alslfglw8
+```
+
+The Klever protocol defines the address of an account as the Bech32 encoding
+of the public key of its corresponding ed25519 keypair (the secret key
+remains known only to the user that owns the keypair). The raw address is 32
+bytes; the resulting Bech32 string is 62 characters total (the `klv1` prefix
+plus 58 base32-encoded data and checksum characters). The encode/decode
+routine in the Klever node sets `fromBits = 8, toBits = 5, pad = true` (see
+[`crypto/pubkeyConverter/bech32PubkeyConverter.go`][klever-pkc]).
+
+Deployed smart contracts on Klever have their raw address prefixed by 8
+zero bytes followed by 2 bytes of VM-type marker (10 prefix bytes total —
+see [`core/address.go`][klever-addr], constants
+`NumInitCharactersForScAddress = 10` and `VMTypeLen = 2`). In Bech32 form
+those addresses always start with `klv1qqqqqqqqqqqq...`. Externally-owned
+accounts and deployed smart contracts share the same CAIP-10 syntax.
+
+## Syntax
+
+```
+caip10-like address:    namespace + ":" + chainId + ":" + address
+namespace:              klv
+chainId:                108 (Mainnet), 109 (Testnet), or 100001 (Devnet) — see CAIP-2
+address:                Bech32-formatted Klever address (klv1...)
+```
+
+The address segment always fits within the `[-.%a-zA-Z0-9]{1,128}` envelope
+mandated by [CAIP-10][].
+
+## Test Cases
+
+Live mainnet addresses from `https://api.mainnet.klever.org/v1.0`:
+
+```
+# Wallet address on Klever Mainnet
+klv:108:klv1edd0ymfmv9r2mxk7mdtsk4zfeql5cp9vyn7t4y4adq58vp2r9alslfglw8
+klv:108:klv16shscvyg2mrxex4zukdsn6rhqje52ekcw8s4kkx69k25jaky943s89u22d
+
+# Deployed smart contract on Klever Mainnet (note klv1qqqqqqqqqqqq... prefix)
+klv:108:klv1qqqqqqqqqqqqqpgqpg2ff85tljne96d2jwedj4mkrhsu3up5c0nq0x8g69
+
+# Klever Testnet
+klv:109:klv1elm4p3z6y66pgdezxcplwnmarwq5np3cvgwr32s335djpa3zqwus5f92gx
+```
+
+## References
+
+- [Klever Wallet documentation][klever-wallet] — End-user surface for Klever
+  addresses.
+- [Klever Connect SDK][klever-connect] — TypeScript reference implementation
+  of the address encode/decode flow.
+- [klever-go node source][klever-go] — Reference implementation of the
+  address layout, the Bech32 converter, and the smart-contract address
+  prefix.
+- [BIP_0173][] — Bech32 specification used for Klever addresses.
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-10]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
+[BIP_0173]: https://en.bitcoin.it/wiki/BIP_0173
+[klever-wallet]: https://klever.org/wallet
+[klever-connect]: https://github.com/klever-io/klever-connect
+[klever-go]: https://github.com/klever-io/klever-go
+[klever-pkc]: https://github.com/klever-io/klever-go/blob/develop/crypto/pubkeyConverter/bech32PubkeyConverter.go
+[klever-addr]: https://github.com/klever-io/klever-go/blob/develop/core/address.go
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/klv/caip19.md
+++ b/klv/caip19.md
@@ -1,0 +1,102 @@
+---
+namespace-identifier: klv-caip19
+title: Klever Namespace - Assets
+author: Nicollas Gabriel da Silva (@nickgs1337)
+discussions-to: https://forum.klever.org/, https://github.com/klever-io/klever-go/discussions
+status: Draft
+type: Standard
+created: 2026-05-13
+requires: ["CAIP-2", "CAIP-19"]
+---
+
+# CAIP-19
+
+_For context, see the [CAIP-19][] specification._
+
+## Rationale
+
+Klever ships a native multi-asset model called **KDA** (Klever Digital Asset)
+that supports fungible tokens, non-fungible tokens (NFTs), and semi-fungible
+tokens (SFTs) as first-class on-chain primitives — assets are not encoded as
+smart-contract balances. The asset type enum is defined in
+[`data/transaction/contracts.pb.go`][klever-contracts] (`Fungible = 0`,
+`NonFungible = 1`, `SemiFungible = 2`).
+
+The single asset namespace `kda` covers fungible, NFT, and SFT tokens. The
+asset type (fungible / NFT / SFT) is metadata returned by the public asset
+API and is not encoded in the CAIP-19 identifier itself.
+
+## Syntax
+
+```
+caip19 asset id:    chainId + "/" + assetNamespace + ":" + assetReference [ + "/" + tokenId ]
+namespace:          klv
+chainId:            108 (Mainnet), 109 (Testnet), or 100001 (Devnet) — see CAIP-2
+assetNamespace:     kda  (covers fungible, NFT, and SFT)
+assetReference:     the on-chain asset id, e.g. KLV, KFI, DVK-34ZH, DVKNFT-1SW5
+tokenId:            (optional) 1-indexed integer instance within an NFT/SFT collection
+```
+
+Klever asset IDs come in two shapes:
+
+- **Protocol assets** — short uppercase tickers minted at genesis (`KLV`,
+  `KFI`).
+- **User-minted assets** — `TICKER-NONCE` form, where `NONCE` is a 4-char
+  base36 (`[0-9A-Z]{4}`) suffix the chain assigns at creation to ensure
+  uniqueness across issuers using the same ticker (`DVK-34ZH`, `WBTC-3FB5`,
+  `DVKNFT-1SW5`). The suffix is generated deterministically by
+  `CreateNewAssetIdentifier` in [`core/process/kda/assetHelper.go`][klever-assethelper]
+  by hashing the caller address, nonce, and ticker, then base36-encoding the
+  first 4 chars (see also `TickerSeparator = "-"` and
+  `TickerRandomSequenceLength = 4` in
+  [`core/process/kda/kdautils/utils.go`][klever-kdautils]).
+
+Both shapes share the `kda` asset namespace.
+
+## Test Cases
+
+Live mainnet asset ids from `https://api.mainnet.klever.org/v1.0/assets/list`:
+
+```
+# Native Klever token (KLV) on Mainnet
+klv:108/kda:KLV
+
+# Native governance token (KFI) on Mainnet
+klv:108/kda:KFI
+
+# User-minted fungible asset on Mainnet
+klv:108/kda:DVK-34ZH
+klv:108/kda:WBTC-3FB5
+
+# NFT collection on Mainnet
+klv:108/kda:DVKNFT-1SW5
+
+# Specific NFT instance #1 within the DVKNFT-1SW5 collection
+klv:108/kda:DVKNFT-1SW5/1
+
+# Testnet KLV
+klv:109/kda:KLV
+```
+
+## References
+
+- [Klever asset metadata endpoint][klever-asset-api] — REST endpoint that
+  returns full KDA metadata (type, precision, max supply, issuer, etc.).
+- [Klever Connect SDK][klever-connect] — TypeScript helpers for resolving
+  asset metadata.
+- [klever-go node source][klever-go] — Reference implementation of the KDA
+  asset creation and identifier-generation logic.
+- [CAIP-19][] — The chain-agnostic asset ID specification.
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[CAIP-19]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
+[klever-asset-api]: https://api.mainnet.klever.org/v1.0/assets
+[klever-connect]: https://github.com/klever-io/klever-connect
+[klever-go]: https://github.com/klever-io/klever-go
+[klever-contracts]: https://github.com/klever-io/klever-go/blob/develop/data/transaction/contracts.pb.go
+[klever-assethelper]: https://github.com/klever-io/klever-go/blob/develop/core/process/kda/assetHelper.go
+[klever-kdautils]: https://github.com/klever-io/klever-go/blob/develop/core/process/kda/kdautils/utils.go
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/klv/caip2.md
+++ b/klv/caip2.md
@@ -1,0 +1,105 @@
+---
+namespace-identifier: klv-caip2
+title: Klever Namespace - Chains
+author: Nicollas Gabriel da Silva (@nickgs1337)
+discussions-to: https://forum.klever.org/, https://github.com/klever-io/klever-go/discussions
+status: Draft
+type: Standard
+created: 2026-05-13
+requires: ["CAIP-2"]
+---
+
+# CAIP-2
+
+_For context, see the [CAIP-2][] specification._
+
+## Abstract
+
+In [CAIP-2][] a general blockchain identification scheme is defined. This
+document is the implementation of CAIP-2 for the Klever blockchain.
+
+### Klever Namespace
+
+The namespace `klv` refers to the wider Klever ecosystem.
+
+## Rationale
+
+The Klever protocol runs a production network (Mainnet), a testing network
+(Testnet) and a development network (Devnet). More may be canonically
+addressed in the future. Each network is identified on-chain by an integer
+`klv_chain_id` assigned at genesis; that integer is the canonical CAIP-2
+reference.
+
+## Syntax
+
+An identifier for a Klever chain consists of the namespace prefix `klv:`
+followed by the chain's integer `klv_chain_id`.
+
+### Reference Definition
+
+The reference is the network's integer chain ID, rendered in base 10 with no
+leading zeros:
+
+- `108` for Mainnet
+- `109` for Testnet
+- `100001` for Devnet
+
+References are within the case-sensitive `[-a-zA-Z0-9]{1,32}` envelope
+mandated by [CAIP-2][].
+
+### Resolution Method
+
+To resolve a blockchain reference for the Klever namespace, query the
+`/node/status` endpoint on any public Klever node, e.g. the official mainnet
+node:
+
+```jsonc
+// Request
+curl -sS https://node.mainnet.klever.org/node/status
+
+// Response (formatted, excerpt)
+{
+  "data": {
+    "metrics": {
+      "klv_chain_id": 108
+      // ... other live chain metrics
+    }
+  },
+  "code": "successful"
+}
+```
+
+The `klv_chain_id` field inside `data.metrics` is the value used directly as
+the `reference` section of a CAIP-2 or CAIP-10.
+
+## Backwards Compatibility
+
+Not applicable.
+
+## Test Cases
+
+```
+# Klever Mainnet
+klv:108
+
+# Klever Testnet
+klv:109
+
+# Klever Devnet
+klv:100001
+```
+
+## References
+
+- [Klever node status endpoint][klever-status] — REST endpoint that returns
+  the live chain ID and other chain identity metrics.
+- [Klever Connect SDK][klever-connect] — Implements chain-id-aware
+  transaction signing.
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[klever-status]: https://node.mainnet.klever.org/node/status
+[klever-connect]: https://github.com/klever-io/klever-connect
+
+## Rights
+
+Copyright and related rights waived via CC0.


### PR DESCRIPTION
This PR adds a new namespace `klv` for the Klever Blockchain, a layer-1 proof-of-stake chain with ed25519 keys, Bech32 addresses prefixed `klv1...`, Wasmer-based smart contracts, and a native multi-asset model (KDA — Klever Digital Asset) that handles fungible tokens, NFTs, and SFTs as first-class on-chain primitives. The namespace covers chain identification (CAIP-2), account references (CAIP-10), and KDA asset references (CAIP-19).

## What changed

A new `klv/` folder containing:

- `README.md` — namespace overview, governance pointer, references to the Klever ecosystem.
- `caip2.md` — chain id profile. References are the integer `klv_chain_id` exposed at `/node/status`. Test cases: `klv:108` (mainnet), `klv:109` (testnet), `klv:100001` (devnet).
- `caip10.md` — account id profile. Bech32 addresses with HRP `klv`, ed25519 keypairs, 32-byte raw address, 62-char total Bech32 string. Documents the smart-contract address pattern (`klv1qqqqqqqqqqqq...`) and includes a real on-chain SC address example from the protocol test suite.
- `caip19.md` — asset id profile. Single asset namespace `kda` covering fungible / NFT / SFT (type lives in metadata, not the identifier). Documents the `TICKER-NONCE` shape where `NONCE` is a 4-character base36 suffix generated deterministically by the protocol.

## Why

Klever has been live on mainnet since 2022 and operates a public block explorer, REST API, and TypeScript SDK, but does not yet have a CAIP-2 namespace registered. Adopting CAIP-2 / CAIP-10 / CAIP-19 lets cross-chain tooling — wallets, indexers, bridges, agent-driven signing surfaces — refer to Klever chains, accounts, and KDA tokens unambiguously without each tool inventing its own shape.

Every technical claim in the namespace files is traced to a specific path in the Klever node source ([klever-io/klever-go][klever-go]) so reviewers can verify directly:

- HRP `klv` with `fromBits=8, toBits=5, pad=true` — [`crypto/pubkeyConverter/bech32PubkeyConverter.go`][klever-pkc]
- ed25519 keypairs — [`crypto/signing/ed25519/`][klever-ed25519]
- Smart-contract address layout (8 zero bytes + 2 VM-type bytes = 10-byte prefix) — [`core/address.go`][klever-addr] (constants `NumInitCharactersForScAddress = 10`, `VMTypeLen = 2`)
- KDA asset type enum (`Fungible = 0`, `NonFungible = 1`, `SemiFungible = 2`) — [`data/transaction/contracts.pb.go`][klever-contracts]
- Asset identifier generation (deterministic base36 4-char suffix after `-` separator) — [`core/process/kda/assetHelper.go`][klever-assethelper] (`CreateNewAssetIdentifier`) and [`core/process/kda/kdautils/utils.go`][klever-kdautils] (`TickerSeparator = "-"`, `TickerRandomSequenceLength = 4`)

The integer chain IDs in CAIP-2 (`klv:108` mainnet, `klv:109` testnet, `klv:100001` devnet) were verified live against `https://node.mainnet.klever.org/node/status` (the `klv_chain_id` field).

SLIP-44 coin type `690` (registered as `KLV` / `KleverChain`) is documented in the [SLIP-44 registry][slip-44].

## References

- [Klever][] — main website.
- [KleverChain explorer][kleverscan] — block explorer for mainnet, testnet, devnet.
- [Klever node REST API][klever-api] — public REST endpoint used to verify chain identity and asset metadata in this PR.
- [klever-go][] — reference Go node implementation; every code citation in the namespace files links here.
- [Klever Connect SDK][klever-connect] — TypeScript reference for address encode/decode.

[klever-go]: https://github.com/klever-io/klever-go
[Klever]: https://klever.org
[kleverscan]: https://kleverscan.org
[klever-api]: https://api.mainnet.klever.org/v1.0
[klever-connect]: https://github.com/klever-io/klever-connect
[klever-pkc]: https://github.com/klever-io/klever-go/blob/develop/crypto/pubkeyConverter/bech32PubkeyConverter.go
[klever-ed25519]: https://github.com/klever-io/klever-go/tree/develop/crypto/signing/ed25519
[klever-addr]: https://github.com/klever-io/klever-go/blob/develop/core/address.go
[klever-contracts]: https://github.com/klever-io/klever-go/blob/develop/data/transaction/contracts.pb.go
[klever-assethelper]: https://github.com/klever-io/klever-go/blob/develop/core/process/kda/assetHelper.go
[klever-kdautils]: https://github.com/klever-io/klever-go/blob/develop/core/process/kda/kdautils/utils.go
[slip-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
