### PR TITLE
Add Neurai mainnet addresses to BIP122 namespaces

### DIFF
--- a/bip122/caip10.md
+++ b/bip122/caip10.md
@@ -81,6 +81,9 @@ bip122:12a765e31ffd4059bada1e25190f6e98:ltc1q8c6fshw2dlwun7ekn9qwf37cu2rn755u9ym
 # Litecoin testnet, Native SegWit address (P2WPKH)
 bip122:4966625a4b2851d9fdee139e56211a0d:tltc1qlustmw64lgd744h45n0t07wxnxw8pmv2sv07r9
 
+# Neurai mainnet, P2PKH address
+bip122:00000044d33c0c0ba019be5c02497304:NX7syqGJzweY57vW2K1D9G3kn8DXSq9Azc
+
 ```
 
 ## References

--- a/bip122/caip2.md
+++ b/bip122/caip2.md
@@ -77,6 +77,9 @@ bip122:4966625a4b2851d9fdee139e56211a0d
 
 # Dogecoin testnet
 bip122:bb0a78264637406b6360aad926284d54
+
+# Neurai mainnet (see https://github.com/NeuraiProject/Neurai)
+bip122:00000044d33c0c0ba019be5c02497304
 ```
 
 ## References


### PR DESCRIPTION
## Summary

Add Neurai (XNA) mainnet as a test case under the existing `bip122` namespace.

Neurai is a UTXO blockchain (Bitcoin / Ravencoin lineage) with its own genesis
block, P2PKH prefix, and SLIP-0044 coin type (1900). It reuses the canonical
`bip122` chain-ID definition — no new namespace is needed.

## Chain identity

- **CAIP-2 Chain ID**: `bip122:00000044d33c0c0ba019be5c02497304`
- **Full genesis hash**: `00000044d33c0c0ba019be5c0249730424a69cb4c222153322f68c6104484806`
- **SLIP-0044 coin type**: `1900` ([registered upstream](https://github.com/satoshilabs/slips/blob/master/slip-0044.md))
- **Mainnet P2PKH prefix**: `0x35` (addresses start with `N`)
- **Address format**: legacy P2PKH only (no SegWit/bech32 in current consensus)

Genesis hash can be reproduced against the official Neurai node:

```bash
neurai-cli getblockhash 0
# 00000044d33c0c0ba019be5c0249730424a69cb4c222153322f68c6104484806​
```

## Related work

- WalletConnect v2 spec for Neurai: https://github.com/NeuraiProject/neurai-walletconnect-spec
- Reference wallet implementation: https://github.com/NeuraiProject/neurai-wallet-walletconnect
- Demo dApp: https://github.com/NeuraiProject/neurai-dapp-demo
- Reown Chain Onboarding submission (parallel): https://github.com/WalletConnect/walletconnect-monorepo/issues/7245


## Notes

- **Testnet not included** in this PR. Neurai's testnet currently auto-mines
  the genesis block per epoch, so there is no stable testnet reference yet.
  A follow-up PR will add testnet once the protocol freezes a stable genesis.
- **Post-quantum keys (ML-DSA-44)** are out of scope for this PR. They will be
  proposed separately if/when the broader namespace ecosystem aligns on
  representing post-quantum addresses.
