### PR TITLE
Add bsv namespace (BSV Blockchain)

### DIFF
--- a/bsv/README.md
+++ b/bsv/README.md
@@ -1,0 +1,61 @@
+---
+namespace-identifier: bsv
+title: BSV Blockchain
+author: Deggen (@sirdeggen) <d.kellenschwiler@bsvassociation.org>
+status: Draft
+type: Informational
+created: 2026-07-10
+requires: ["CAIP-2"]
+---
+
+# Namespace for the BSV Blockchain
+
+BSV is a proof-of-work UTXO blockchain descended from the original Bitcoin protocol.
+This namespace identifies BSV networks (mainnet and testnet) by their human-readable
+network name, mirroring how BSV wallets and application infrastructure already refer
+to the network they operate on.
+
+## Rationale
+
+BSV shares its genesis block with BTC and BCH, all three tracing back to Satoshi's
+2009 genesis block. The [bip122][] namespace disambiguates such forks by using the
+hash of the first block *after* divergence rather than the genesis hash — Bitcoin Cash,
+for example, is registered as `bip122:000000000000000000651ef99cb9fcbe`. A BSV
+identifier could in principle be constructed the same way, from BSV's fork block.
+
+This namespace exists for a different reason. The BSV application layer — BRC-100
+wallets, overlay services, ARC transaction broadcasters, and SPV clients — universally
+identifies a network by a stable human-readable name (`mainnet` / `testnet`), never by
+a fork-block hash. A BRC-100 wallet self-reports its network via a `getNetwork` call
+returning `mainnet` or `testnet`; SV Node's `getblockchaininfo` returns a `chain` field
+of `main` or `test`. A CAIP-2 identifier that mirrors this name lets cross-chain tooling
+(payment protocols such as x402, CAIP-10 account references, CAIP-19 asset references)
+map directly onto the identifiers applications already exchange, without a full-node RPC
+round-trip to recover a fork-block hash. Following the precedent set by the [casper][]
+namespace, whose Chain ID "should not be confused with the genesis_hash," this namespace
+uses the network name as the CAIP-2 reference.
+
+## Governance
+
+The BSV protocol is stewarded by the [BSV Association][], a Switzerland-based
+non-profit that maintains the network's technical standards and the reference node
+implementation. Application-layer standards are published through the openly editable
+[BRC (Bitcoin Request for Comment)][BRCs] process, which defines wallet interfaces
+(BRC-100), key derivation (BRC-42/BRC-43), payment protocols (BRC-29), and transaction
+serialization (BRC-62/BRC-95), among others. Changes to this namespace should be
+discussed with the BSV Association and the BRC maintainers.
+
+## References
+
+- [BSV Association][] - the non-profit stewarding the BSV protocol and its standards
+- [BRCs][] - the Bitcoin Request for Comment repository defining BSV application standards
+- [bip122][] - the CAIP-2 namespace for Bitcoin-based networks, which identifies forks by fork-block hash
+- [casper][] - a CAIP-2 namespace precedent using a human-readable Chain ID rather than a genesis hash
+
+[BSV Association]: https://www.bsvblockchain.org/
+[BRCs]: https://github.com/bitcoin-sv/BRCs
+[bip122]: https://namespaces.chainagnostic.org/bip122/README
+[casper]: https://namespaces.chainagnostic.org/casper/README
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/bsv/README.md
+++ b/bsv/README.md
@@ -52,7 +52,7 @@ The BSV protocol is stewarded by the [BSV Association][], a Switzerland-based
 non-profit that maintains the network's technical standards and the reference node
 implementation. Application-layer standards are published through the openly editable
 [BRC (Bitcoin Request for Comment)][BRCs] process, which defines wallet interfaces
-(BRC-100), key derivation (BRC-42/BRC-43), payment protocols (BRC-29), and transaction
+([BRC-100]), key derivation (BRC-42/BRC-43), payment protocols (BRC-29), and transaction
 serialization (BRC-62/BRC-95), among others. Changes to this namespace should be
 discussed with the BSV Association and the BRC maintainers.
 

--- a/bsv/README.md
+++ b/bsv/README.md
@@ -11,9 +11,16 @@ requires: ["CAIP-2"]
 # Namespace for the BSV Blockchain
 
 BSV is a proof-of-work UTXO blockchain descended from the original Bitcoin protocol.
-This namespace identifies BSV networks (mainnet and testnet) by their human-readable
-network name, mirroring how BSV wallets and application infrastructure already refer
-to the network they operate on.
+This namespace identifies BSV networks by their human-readable network name, mirroring
+how BSV wallets and application infrastructure already refer to the network they
+operate on.
+
+Registered networks:
+
+- `bsv:mainnet` — BSV main network
+- `bsv:testnet` — BSV public test network
+- `bsv:ttn` — Teranode Test Net (public Teranode scaling test network / Teratestnet)
+- `bsv:tstn` — Teranode Scaling Test Net (private, per-deployment scaling test network)
 
 ## Rationale
 
@@ -25,15 +32,19 @@ identifier could in principle be constructed the same way, from BSV's fork block
 
 This namespace exists for a different reason. The BSV application layer — BRC-100
 wallets, overlay services, ARC transaction broadcasters, and SPV clients — universally
-identifies a network by a stable human-readable name (`mainnet` / `testnet`), never by
-a fork-block hash. A BRC-100 wallet self-reports its network via a `getNetwork` call
-returning `mainnet` or `testnet`; SV Node's `getblockchaininfo` returns a `chain` field
-of `main` or `test`. A CAIP-2 identifier that mirrors this name lets cross-chain tooling
-(payment protocols such as x402, CAIP-10 account references, CAIP-19 asset references)
-map directly onto the identifiers applications already exchange, without a full-node RPC
-round-trip to recover a fork-block hash. Following the precedent set by the [casper][]
-namespace, whose Chain ID "should not be confused with the genesis_hash," this namespace
-uses the network name as the CAIP-2 reference.
+identifies a network by a stable human-readable name, never by a fork-block hash.
+A BRC-100 wallet self-reports its network via a `getNetwork` call; SV Node's
+`getblockchaininfo` returns a `chain` field of `main` or `test`. A CAIP-2 identifier
+that mirrors this name lets cross-chain tooling (payment protocols such as x402,
+CAIP-10 account references, CAIP-19 asset references) map directly onto the
+identifiers applications already exchange, without a full-node RPC round-trip to
+recover a fork-block hash. Following the precedent set by the [casper][] namespace,
+whose Chain ID "should not be confused with the genesis_hash," this namespace uses
+the network name as the CAIP-2 reference.
+
+`ttn` and `tstn` are included so high-throughput payment protocols can exercise
+Teranode test environments without overloading `bsv:testnet` or inventing ad-hoc
+names that later need client migration.
 
 ## Governance
 

--- a/bsv/README.md
+++ b/bsv/README.md
@@ -65,6 +65,7 @@ discussed with the BSV Association and the BRC maintainers.
 
 [BSV Association]: https://www.bsvblockchain.org/
 [BRCs]: https://github.com/bitcoin-sv/BRCs
+[BRC-100]: https://github.com/bitcoin-sv/BRCs/blob/master/wallet/0100.md
 [bip122]: https://namespaces.chainagnostic.org/bip122/README
 [casper]: https://namespaces.chainagnostic.org/casper/README
 

--- a/bsv/caip2.md
+++ b/bsv/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: bsv-caip2
 title: BSV Blockchain - Networks
 author: Deggen (@sirdeggen) <d.kellenschwiler@bsvassociation.org>
-discussions-to: ["https://github.com/ChainAgnostic/namespaces/pull/190", "https://github.com/bsv-blockchain/x402/pull/1"]
+discussions-to: ["https://github.com/ChainAgnostic/namespaces/pull/190", "https://github.com/x402-foundation/x402/pull/2890"]
 status: Draft
 type: Standard
 created: 2026-07-10
@@ -23,33 +23,38 @@ not the genesis block hash, which BSV shares with BTC and BCH.
 
 ### Semantics
 
-BSV networks are identified by a stable, well-known network name assigned by the
-protocol's reference node implementation (SV Node). Mainnet and testnet are the two
-networks in general use; the scaling test network (STN) and regtest exist for testing
-and MAY be added to this namespace if cross-chain tooling requires them.
+BSV networks are identified by a stable, well-known network name. This namespace
+registers the networks in general use for production and public/private scaling
+tests. Classic mainnet and testnet remain the baseline networks; Teranode Test Net
+(`ttn`) and Teranode Scaling Test Net (`tstn`) identify the Teranode-era scaling
+test networks. Local-only environments such as regtest/mockchain are out of scope
+for this registration.
 
 ### Syntax
 
 The Chain ID consists of the prefix `bsv:` followed by the network name.
 
 The reference is a case-sensitive string matching the CAIP-2 reference grammar
-`[-_a-zA-Z0-9]{1,32}`. This namespace defines two references:
+`[-_a-zA-Z0-9]{1,32}`. This namespace defines four references:
 
 - `mainnet` — the BSV main network
-- `testnet` — the BSV test network
+- `testnet` — the BSV public test network
+- `ttn` — Teranode Test Net (public Teranode scaling test network; also known as Teratestnet)
+- `tstn` — Teranode Scaling Test Net (private, per-deployment Teranode scaling test network)
 
 A validating regular expression for the fully-qualified Chain ID:
 
 ```
-bsv:(mainnet|testnet)
+bsv:(mainnet|testnet|ttn|tstn)
 ```
 
 ### Resolution Mechanics
 
 To resolve the network name for a BSV node, send a JSON-RPC `getblockchaininfo`
 request; the `chain` field of the result identifies the network. Map the node's
-`chain` value to the CAIP-2 reference as follows: `main` → `mainnet`,
-`test` → `testnet`.
+`chain` value to the CAIP-2 reference as follows where applicable: `main` →
+`mainnet`, `test` → `testnet`. Teranode deployments that self-identify as `ttn`
+or `tstn` map to those references unchanged.
 
 ```jsonc
 // Request
@@ -70,8 +75,10 @@ request; the `chain` field of the result identifies the network. Map the node's
 
 Application-layer clients typically resolve the network without a node round-trip: a
 [BRC-100][] wallet returns the network directly from its `getNetwork` call
-(`{ "network": "mainnet" }` or `{ "network": "testnet" }`), which maps to the CAIP-2
-reference unchanged.
+(e.g. `{ "network": "mainnet" }` or `{ "network": "testnet" }`), which maps to the
+CAIP-2 reference for mainnet/testnet. Wallets and services that operate on Teranode
+test networks SHOULD report `ttn` or `tstn` so the CAIP-2 reference matches the
+application-layer identifier without translation.
 
 ## Rationale
 
@@ -83,12 +90,18 @@ that is the identifier BSV's wallet and infrastructure layer already exchanges �
 namespace [README][] for the full rationale. This mirrors the [casper][] namespace, which
 likewise uses a human-readable Chain ID distinct from the genesis hash.
 
+`ttn` and `tstn` are registered now so payment and cross-chain tooling (e.g. x402) can
+target Teranode test environments without overloading `bsv:testnet` or inventing
+ad-hoc identifiers that later need migration.
+
 ### Backwards Compatibility
 
 No prior CAIP or namespace assigns BSV identifiers, so there are no legacy identifiers to
 maintain. Tooling that prefers a hash-based identifier can independently register BSV under
 [bip122][] using its fork-block hash; the two schemes can coexist without collision because
-they occupy different namespaces.
+they occupy different namespaces. Clients MUST NOT treat a `bip122` identifier that only
+names the shared genesis block as a BSV network — that reference is ambiguous across the
+BTC/BCH/BSV split.
 
 ## Test Cases
 
@@ -100,6 +113,12 @@ bsv:mainnet
 
 # BSV Testnet
 bsv:testnet
+
+# BSV Teranode Test Net (Teratestnet)
+bsv:ttn
+
+# BSV Teranode Scaling Test Net
+bsv:tstn
 ```
 
 ## References

--- a/bsv/caip2.md
+++ b/bsv/caip2.md
@@ -1,0 +1,120 @@
+---
+namespace-identifier: bsv-caip2
+title: BSV Blockchain - Networks
+author: Deggen (@sirdeggen) <d.kellenschwiler@bsvassociation.org>
+discussions-to: ["https://github.com/ChainAgnostic/namespaces/pull/190", "https://github.com/bsv-blockchain/x402/pull/1"]
+status: Draft
+type: Standard
+created: 2026-07-10
+requires: ["CAIP-2"]
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Introduction
+
+The BSV Chain ID is a human-readable identifier for a BSV network. It is the network
+name a BSV node and its client tooling use to describe the chain they operate on —
+not the genesis block hash, which BSV shares with BTC and BCH.
+
+## Specification
+
+### Semantics
+
+BSV networks are identified by a stable, well-known network name assigned by the
+protocol's reference node implementation (SV Node). Mainnet and testnet are the two
+networks in general use; the scaling test network (STN) and regtest exist for testing
+and MAY be added to this namespace if cross-chain tooling requires them.
+
+### Syntax
+
+The Chain ID consists of the prefix `bsv:` followed by the network name.
+
+The reference is a case-sensitive string matching the CAIP-2 reference grammar
+`[-_a-zA-Z0-9]{1,32}`. This namespace defines two references:
+
+- `mainnet` — the BSV main network
+- `testnet` — the BSV test network
+
+A validating regular expression for the fully-qualified Chain ID:
+
+```
+bsv:(mainnet|testnet)
+```
+
+### Resolution Mechanics
+
+To resolve the network name for a BSV node, send a JSON-RPC `getblockchaininfo`
+request; the `chain` field of the result identifies the network. Map the node's
+`chain` value to the CAIP-2 reference as follows: `main` → `mainnet`,
+`test` → `testnet`.
+
+```jsonc
+// Request
+{
+  "jsonrpc": "1.0",
+  "id": 1,
+  "method": "getblockchaininfo",
+  "params": []
+}
+
+// Response (abridged)
+{
+  "result": {
+    "chain": "main"
+  }
+}
+```
+
+Application-layer clients typically resolve the network without a node round-trip: a
+[BRC-100][] wallet returns the network directly from its `getNetwork` call
+(`{ "network": "mainnet" }` or `{ "network": "testnet" }`), which maps to the CAIP-2
+reference unchanged.
+
+## Rationale
+
+BSV descends from the original Bitcoin protocol and therefore shares Satoshi's genesis
+block with BTC and BCH. The [bip122][] namespace addresses this by referencing the hash
+of a chain's first post-fork block (as it does for Bitcoin Cash), so a BSV entry under
+`bip122` is technically possible. This namespace instead uses the network name because
+that is the identifier BSV's wallet and infrastructure layer already exchanges — see the
+namespace [README][] for the full rationale. This mirrors the [casper][] namespace, which
+likewise uses a human-readable Chain ID distinct from the genesis hash.
+
+### Backwards Compatibility
+
+No prior CAIP or namespace assigns BSV identifiers, so there are no legacy identifiers to
+maintain. Tooling that prefers a hash-based identifier can independently register BSV under
+[bip122][] using its fork-block hash; the two schemes can coexist without collision because
+they occupy different namespaces.
+
+## Test Cases
+
+This is a list of manually composed examples:
+
+```
+# BSV Mainnet
+bsv:mainnet
+
+# BSV Testnet
+bsv:testnet
+```
+
+## References
+
+- [BRC-100][] - the BSV wallet-to-application interface, whose `getNetwork` method reports the network name
+- [bip122][] - the CAIP-2 namespace for Bitcoin-based networks, which identifies forks by fork-block hash
+- [casper][] - a CAIP-2 namespace precedent using a human-readable Chain ID rather than a genesis hash
+- [README][] - the BSV namespace README with the full rationale
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[BRC-100]: https://github.com/bitcoin-sv/BRCs/blob/master/wallet/0100.md
+[bip122]: https://namespaces.chainagnostic.org/bip122/caip2
+[casper]: https://namespaces.chainagnostic.org/casper/caip2
+[README]: ./README.md
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

Adds a new namespace, `bsv`, for the BSV Blockchain, with a complete `README.md` and CAIP-2 profile. Registers four Chain IDs:

- `bsv:mainnet` — BSV main network
- `bsv:testnet` — BSV public test network
- `bsv:ttn` — Teranode Test Net (public Teranode scaling test network / Teratestnet)
- `bsv:tstn` — Teranode Scaling Test Net (private, per-deployment scaling test network)

## Approach and rationale

BSV descends from the original Bitcoin protocol and shares Satoshi's genesis block with BTC and BCH. I want to be upfront that `bip122` *can* represent BSV: it disambiguates forks by the first post-fork block hash (as it does for Bitcoin Cash, `bip122:000000000000000000651ef99cb9fcbe`), and a BSV entry could be built the same way from its fork block.

This namespace uses the **human-readable network name** as the CAIP-2 reference instead, following the [casper](https://namespaces.chainagnostic.org/casper/caip2) precedent (a Chain ID that "should not be confused with the genesis_hash"). The reason is that the BSV application layer — BRC-100 wallets, overlay services, ARC broadcasters, SPV clients — universally identifies a network by name, never by fork-block hash. A BRC-100 wallet self-reports via `getNetwork` → `mainnet`/`testnet` (and `ttn`/`tstn` on Teranode deployments); SV Node's `getblockchaininfo.chain` returns `main`/`test`. Cross-chain tooling (e.g. the x402 payment protocol, CAIP-10/CAIP-19 references) can then map directly onto identifiers applications already exchange without a full-node round-trip. The two schemes can coexist — a hash-based `bip122` BSV entry and this name-based one occupy different namespaces.

`ttn` and `tstn` are registered up front so high-throughput payment protocols can target Teranode test environments without overloading `bsv:testnet` or inventing ad-hoc names that later need client migration. Clients MUST NOT treat a genesis-only `bip122` identifier as a BSV network — that reference is ambiguous across the BTC/BCH/BSV split.

Resolution mechanics, syntax (`bsv:(mainnet|testnet|ttn|tstn)`), and test cases are in `bsv/caip2.md`.

## Context

This registration supports adding BSV as a payment mechanism to the [x402 protocol](https://github.com/x402-foundation/x402/pull/2890), where the design discussion for these identifiers is ongoing. Happy to adjust the reference scheme (including moving to `bip122`) based on editor guidance.

Author: @sirdeggen (BSV Association).