### PR TITLE
Add Supra Namespace

### DIFF
--- a/supra/README.md
+++ b/supra/README.md
@@ -2,7 +2,7 @@
 namespace-identifier: supra
 title: Supra Ecosystem
 author: Bharat Jain <supra-bharatjain>
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/PENDING
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/192
 status: Draft
 type: Informational
 created: 2026-07-21

--- a/supra/README.md
+++ b/supra/README.md
@@ -1,0 +1,34 @@
+---
+namespace-identifier: supra
+title: Supra Ecosystem
+author: Bharat Jain <supra-bharatjain>
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/PENDING
+status: Draft
+type: Informational
+created: 2026-07-21
+updated: 2026-07-21
+---
+
+# Namespace for Supra chains
+
+## Introduction
+
+Blockchains in the "supra" namespace are identified by their numeric `chain_id`;
+each network is maintained by a set of validators with its own REST RPC
+endpoints. Supra is a Layer 1 blockchain built on Move, with vertically
+integrated services — native price oracles, distributed verifiable randomness
+(dVRF), and on-chain automation.
+
+## Syntax
+
+The namespace "supra" refers to the Supra open-source blockchain platform.
+
+## References
+
+- [Supra Docs](https://docs.supra.com/)
+- [Supra GitHub](https://github.com/Entropy-Foundation)
+- [Supra Network](https://supra.com/)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/supra/caip2.md
+++ b/supra/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: supra-caip2
 title: Supra Namespace - Chains
 author: Bharat Jain <supra-bharatjain>
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/PENDING
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/192
 status: Draft
 type: Standard
 created: 2026-07-21

--- a/supra/caip2.md
+++ b/supra/caip2.md
@@ -1,0 +1,85 @@
+---
+namespace-identifier: supra-caip2
+title: Supra Namespace - Chains
+author: Bharat Jain <supra-bharatjain>
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/PENDING
+status: Draft
+type: Standard
+created: 2026-07-21
+updated: 2026-07-21
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Rationale
+
+In CAIP-2 a general blockchain identification scheme is defined. This is the
+implementation of CAIP-2 for Supra. Blockchains in the "supra" namespace are
+identified by their numeric `chain_id`, assigned at genesis. Each network is
+maintained by a set of validators with its own REST RPC endpoints. These chain
+IDs require no transformations to be used as conformant CAIP-2 references.
+
+## Syntax
+
+The namespace "supra" refers to the Supra open-source blockchain platform.
+
+### Reference Definition
+
+The definition for this namespace will use the `chain_id` as an identifier
+for different Supra chains. The chain ID is a positive integer assigned at
+genesis:
+
+| Network | Chain ID |
+|---------|----------|
+| Mainnet | 8        |
+| Testnet | 6        |
+
+### Resolution Method
+
+To resolve a blockchain reference for the Supra namespace, make an HTTP GET
+request to the REST RPC of a fullnode, for example:
+
+```bash
+curl https://rpc-mainnet.supra.com/rpc/v3/transactions/chain_id
+```
+
+```jsonc
+// Response
+8
+```
+
+The response is the `chain_id` as an integer that can be used directly as the
+CAIP-2 reference.
+
+### Backwards Compatibility
+
+Not applicable
+
+## Test Cases
+
+This is a list of manually composed examples
+
+```bash
+# Supra Mainnet
+supra:8
+
+# Supra Testnet
+supra:6
+
+```
+
+## References
+
+- [REST RPC][] - REST RPC reference in Supra official documentation
+- [Networks][] - Supra network information and endpoints
+
+[CAIP-2]: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+[REST RPC]: https://docs.supra.com/network/move/rest-api
+[Networks]: https://docs.supra.com/network/network-information
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Add Supra namespace

This PR introduces the Supra namespace to the ChainAgnostic namespaces registry.

### Added Files

- `supra/README.md` - Namespace profile for the Supra ecosystem
- `supra/caip2.md` - CAIP-2 chain identification specification for Supra

### Summary

[Supra](https://supra.com/) is a Layer 1 blockchain built on Move, with vertically integrated services — native price oracles, distributed verifiable randomness (dVRF), and on-chain automation. This PR establishes the `supra` namespace for identifying Supra-based chains.

#### Chain Identification (CAIP-2)

Chains in the Supra namespace are identified by their numeric `chain_id`, which is assigned at genesis and requires no transformation to be used as a CAIP-2 reference.

| Network | Chain ID | CAIP-2 Identifier |
|---------|----------|-------------------|
| Mainnet | 8        | `supra:8`         |
| Testnet | 6        | `supra:6`         |

#### Resolution

To resolve a blockchain reference for the Supra namespace, make an HTTP GET
request to the REST RPC of a fullnode, for example:

```bash
// Mainnet - 8
curl https://rpc-mainnet.supra.com/rpc/v3/transactions/chain_id
// Testnet - 6
curl https://rpc-testnet.supra.com/rpc/v3/transactions/chain_id
```
The response is the `chain_id` as an integer that can be used directly as the
CAIP-2 reference.

### References
- [Supra Docs](https://docs.supra.com/)
- [Supra GitHub](https://github.com/Entropy-Foundation)
- [Supra Network](https://supra.com/)