### PR TITLE
fix: solana caip350 binary representation is the full 32 bytes

### DIFF
--- a/eip155/caip350.md
+++ b/eip155/caip350.md
@@ -112,6 +112,7 @@ Wallets and other software are expected to be able to fetch the extra informatio
 
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 [CAIP-104]: https://chainagnostic.org/CAIPs/caip-104
+[CAIP-350]: https://chainagnostic.org/CAIPs/caip-350
 [EIP-55]: https://eips.ethereum.org/EIPS/eip-55
 [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
 [EIP-2294]: https://eips.ethereum.org/EIPS/eip-2294

--- a/solana/caip350.md
+++ b/solana/caip350.md
@@ -41,7 +41,7 @@ It is assumed wallets and other software will be able to differentiate between c
 
 ### Binary representation
 
-To obtain the binary representation from the base58btc-encoded genesis blockhash, first truncate the base58btc-encoded text to its first 32 characters as described above and then decode it to raw bytes.
+The binary representation is the 32 raw bytes obtained by base58btc-decoding the full 44-character genesis blockhash. The truncation described above applies only to the [CAIP-2] text form, never to the binary one: decoding the truncated 32-character string yields 23 bytes, which is neither a valid genesis blockhash nor a prefix of one [^1].
 
 #### Text -> binary conversion
 
@@ -113,3 +113,4 @@ Wallets and other software are expected to be able to fetch the extra informatio
 
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 [CAIP-104]: https://chainagnostic.org/CAIPs/caip-104
+[CAIP-350]: https://chainagnostic.org/CAIPs/caip-350


### PR DESCRIPTION
Closes #173 — @bumblefudge was right, decoding the truncated string gives you 23 bytes, not 32.

The binary representation section told you to truncate the base58btc text to 32 characters *and then* decode:

```
5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp              -> 23 bytes  e15de390a1bfea...
5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d  -> 32 bytes  45296998a6f8e2...
```

Everything else in the profile already says 32 bytes: the text representation is the full 44-character blockhash, `Text -> binary conversion` is a plain base58btc decode with no truncation, and the worked example shows the full hash. Footnote 1 warns against exactly this. Only that one sentence disagreed, so it's now stated the other way round — truncation belongs to the CAIP-2 text form only.

Also defines the missing `[CAIP-350]` link reference in `solana/caip350.md` and `eip155/caip350.md`; both cite it in the note under Text representation but neither declares it, so it renders as literal brackets on the site. `bip122` and `starknet` already have it.