### PR TITLE
Add Pi Network (pinet) namespace and CAIP-2

### DIFF
--- a/pinet/README.md
+++ b/pinet/README.md
@@ -1,0 +1,75 @@
+---
+namespace-identifier: pinet
+title: Pi Network Ecosystem
+author: Hakkyung Lee (@hklee93)
+status: Draft
+type: Informational
+created: 2026-08-04
+requires: ["CAIP-2"]
+---
+
+# Namespace for Pi Network Chains
+
+The `pinet` namespace gives software a consistent way to distinguish Pi Network
+chains from one another and from other blockchain ecosystems.
+For example, `pinet:mainnet` identifies Pi Network Mainnet, while
+`pinet:testnet` identifies Pi Network Testnet.
+
+## Rationale
+
+Pi Network is a Layer 1 blockchain with distinct Mainnet and Testnet
+environments.
+Although its protocol and transaction model are derived from Stellar, Pi
+Network has its own governance, validator set, native asset, public
+infrastructure, and network passphrases.
+Reusing the `stellar` namespace would therefore obscure the operational and
+trust boundaries between the ecosystems and could cause software to resolve a
+Pi chain as a Stellar network.
+
+The `pinet` namespace keeps those boundaries explicit while retaining short,
+human-readable chain references.
+Each reference maps deterministically to an exact, case-sensitive Pi Network
+passphrase exposed by the network's Horizon API.
+Wallets, applications, and cross-chain systems can use that mapping to verify
+which Pi Network environment they are connected to before processing accounts,
+assets, or transactions.
+The mapping and its resolution procedure are defined in the
+[Pi Network CAIP-2 Profile][].
+
+## Governance
+
+Pi Network protocol and public-network upgrades are coordinated by the Pi Core
+Team and communicated through official Pi Network announcements and developer
+documentation.
+Node operators and infrastructure providers adopt the corresponding software
+and configuration updates for each network.
+
+Changes to this namespace follow the review process of the Chain Agnostic
+`namespaces` repository.
+A new chain reference should be added only when Pi Network exposes a stable
+environment with a distinct network passphrase and deterministic resolution
+mechanics.
+Temporary or private deployments should not be assigned a shared reference
+unless they become persistent interoperability targets.
+
+## References
+
+- [Pi Network CAIP-2 Profile][] - Defines Pi Network chain identifiers and
+  their resolution mechanics.
+- [CAIP-2][] - Defines the chain-agnostic blockchain identifier format.
+- [Pi Whitepaper][] - Introduces the Pi Network protocol, ecosystem, and
+  governance model.
+- [Pi Developer Documentation][] - Documents Pi Network application and
+  blockchain integration.
+- [Pi Network Updates][] - Publishes protocol and public-network upgrade
+  announcements.
+
+[Pi Network CAIP-2 Profile]: ./caip2.md
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[Pi Whitepaper]: https://minepi.com/white-paper/
+[Pi Developer Documentation]: https://developers.minepi.com/
+[Pi Network Updates]: https://minepi.com/category/update/
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/pinet/README.md
+++ b/pinet/README.md
@@ -2,9 +2,10 @@
 namespace-identifier: pinet
 title: Pi Network Ecosystem
 author: Hakkyung Lee (@hklee93)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/199
 status: Draft
 type: Informational
-created: 2026-08-04
+created: 2026-08-19
 requires: ["CAIP-2"]
 ---
 
@@ -68,6 +69,7 @@ unless they become persistent interoperability targets.
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
 [Pi Whitepaper]: https://minepi.com/white-paper/
 [Pi Developer Documentation]: https://developers.minepi.com/
+[Pi Developer JS SDK]: https://github.com/pi-apps/pi-platform-docs/
 [Pi Network Updates]: https://minepi.com/category/update/
 
 ## Copyright

--- a/pinet/caip2.md
+++ b/pinet/caip2.md
@@ -1,0 +1,151 @@
+---
+namespace-identifier: pinet-caip2
+title: Pi Network - Blockchain ID Specification
+author: Hakkyung Lee (@hklee93)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/XXX
+status: Draft
+type: Informational
+created: 2026-08-04
+requires: CAIP-2
+---
+
+# CAIP-2
+
+_For context, see the [CAIP-2][] specification._
+
+## Introduction
+
+This document specifies the `pinet` namespace for Pi Network chain identifiers that conform to [CAIP-2][].
+
+Pi Network operates Mainnet and Testnet as separate networks with distinct network passphrases.
+
+## Specification
+
+### Semantics
+
+The `chain_id` is a human-readable identifier for a Pi Network environment.
+
+The following references and network passphrases are defined:
+
+| CAIP-2 chain ID | Pi Network environment | Exact network passphrase |
+| --------------- | ---------------------- | ------------------------ |
+| `pinet:mainnet` | Pi Network Mainnet     | `Pi Network`             |
+| `pinet:testnet` | Pi Network Testnet     | `Pi Testnet`             |
+
+Network passphrases are case-sensitive.
+
+### Syntax
+
+The namespace is `pinet`.
+
+The reference is either `mainnet` or `testnet`.
+
+The complete chain ID MUST match the following regular expression:
+
+```regex
+^pinet:(mainnet|testnet)$
+```
+
+### Resolution Mechanics
+
+An implementation resolves a candidate Pi Network Horizon endpoint by sending an HTTP `GET` request to its root path and reading the `network_passphrase` field from the JSON response.
+
+For example (mainnet):
+
+```console
+$ curl https://api.mainnet.minepi.com/
+```
+
+An abridged Mainnet response contains:
+
+```json
+{
+  "network_passphrase": "Pi Network"
+}
+```
+
+For example (testnet):
+
+```console
+$ curl https://api.testnet.minepi.com/
+```
+
+An abridged Testnet response contains:
+
+```json
+{
+  "network_passphrase": "Pi Testnet"
+}
+```
+
+The implementation MUST compare the returned value exactly and case-sensitively.
+
+The implementation MUST resolve `Pi Network` to `pinet:mainnet`.
+
+The implementation MUST resolve `Pi Testnet` to `pinet:testnet`.
+
+The implementation MUST reject an unrecognized network passphrase instead of inferring a chain ID.
+
+Implementations MAY use another trusted endpoint that exposes the same Horizon root response.
+
+## Rationale
+
+Pi Network constitutes a separate ecosystem with its own networks, governance, validators, native asset, public infrastructure, and network passphrases.
+
+Human-readable references were selected because Pi Network's exact, case-sensitive network passphrases provide deterministic resolution.
+
+### Backwards Compatibility
+
+There are no previously standardized CAIP-2 identifiers for Pi Network chains.
+
+Applications using non-standard identifiers will need to map them to `pinet:mainnet` or `pinet:testnet`.
+
+## Test Cases
+
+The following chain IDs are valid:
+
+```text
+pinet:mainnet
+pinet:testnet
+```
+
+The following values are invalid:
+
+```text
+pi:mainnet
+pinet:pubnet
+pinet:Mainnet
+pinet:Pi Testnet
+```
+
+`pi:mainnet` is invalid because `pi` does not satisfy the minimum namespace length required by [CAIP-2][].
+
+The other invalid values do not match a reference defined by this specification.
+
+## Additional Considerations
+
+Future Pi Network environments require an update to this document and deterministic resolution mechanics before receiving a `pinet` chain reference.
+
+## References
+
+- [CAIP-2][] - Defines the chain-agnostic blockchain identifier format.
+- [CAIP-104][] - Defines the purpose and authoring guidelines for namespace
+  references.
+- [Pi Whitepaper][] - Introduces the Pi Network protocol and ecosystem.
+- [Pi Developer Documentation][] - Documents Pi Network application and
+  blockchain integration.
+- [Pi Mainnet Horizon][] - Exposes the Mainnet Horizon root response used for
+  resolution.
+- [Pi Testnet Horizon][] - Exposes the Testnet Horizon root response used for
+  resolution.
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-104]: https://chainagnostic.org/CAIPs/caip-104
+[Pi Whitepaper]: https://minepi.com/white-paper/
+[Pi Developer Documentation]: https://developers.minepi.com/
+[Pi Mainnet Horizon]: https://api.mainnet.minepi.com/
+[Pi Testnet Horizon]: https://api.testnet.minepi.com/
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/pinet/caip2.md
+++ b/pinet/caip2.md
@@ -2,10 +2,10 @@
 namespace-identifier: pinet-caip2
 title: Pi Network - Blockchain ID Specification
 author: Hakkyung Lee (@hklee93)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pull/XXX
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/199
 status: Draft
 type: Informational
-created: 2026-08-04
+created: 2026-08-19
 requires: CAIP-2
 ---
 


### PR DESCRIPTION
- Proposing `pinet` namespace and its CAIP-2 for Pi Network (Pi)