### PR TITLE
Add Animica namespace (animica:1) — CAIP-2/10/19

### DIFF
--- a/animica/README.md
+++ b/animica/README.md
@@ -2,7 +2,7 @@
 namespace-identifier: animica
 title: Animica
 author: Animica (@animicaorg)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/200
 status: Draft
 type: Informational
 created: 2026-08-22

--- a/animica/README.md
+++ b/animica/README.md
@@ -1,0 +1,70 @@
+---
+namespace-identifier: animica
+title: Animica
+author: Animica (@animicaorg)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+status: Draft
+type: Informational
+created: 2026-08-22
+requires: ["CAIP-2", "CAIP-10", "CAIP-19"]
+---
+
+# Namespace for Animica chains
+
+Animica is an open-source proof-of-work Layer 1 whose accounts sign with post-quantum ML-DSA-65 ([FIPS 204][]) signatures and whose smart contracts run in a Python virtual machine.
+Its mainnet has been live since 2026-04-06 and its native token is ANM, denominated in nano-ANM (1 ANM = 10^9 nANM).
+The `animica` namespace covers networks that implement the Animica protocol and expose its native JSON-RPC interface.
+Individual networks are identified by their integer chain id, as specified in the [Animica CAIP-2 profile][CAIP-2 Profile].
+
+The mainnet identifier `animica:1` is already in production use.
+Animica's [x402][] payment lane settles in ANM against the network id `animica:1`, and its published MCP tooling and [chain parameters][Chain Parameters] use the same identifier.
+This namespace documents that identifier and the account and asset forms that build on it, so that chain-agnostic wallets, payment protocols, and SDKs can refer to Animica without inventing their own conventions.
+
+## Rationale
+
+Animica is not an EVM chain and cannot be placed in the `eip155` namespace.
+Its node exposes a handful of `eth_*`-style convenience methods (for example `eth_gasPrice`), but its addresses are bech32m strings carrying a signature-scheme id and a SHA3-256 key digest, its transactions are canonical CBOR signed with ML-DSA-65, and its chain id `1` would collide with Ethereum mainnet under `eip155:1`.
+A dedicated namespace with the native integer chain id as the reference gives applications an identifier that matches what the node itself reports and what is already exchanged on the wire.
+
+The same bech32m human-readable part `anim` is used on every Animica network.
+The CAIP-2 portion of an identifier is therefore the only thing that distinguishes an account or asset on mainnet from the same account or asset on a test network.
+
+## Governance
+
+Animica's protocol and reference node are developed in the open in the [Animica source repository][].
+Protocol changes ship as versioned releases of the node software and activate at pre-announced block heights; there is no on-chain governance mechanism.
+Changes to this namespace profile should be proposed on the pull request linked in the `discussions-to` header or as an issue in the source repository.
+
+## References
+
+- [Animica website][] - Project overview and downloads
+- [Animica CAIP-2 profile][CAIP-2 Profile] - Chain identifiers in this namespace
+- [Animica CAIP-10 profile][CAIP-10 Profile] - Account identifiers in this namespace
+- [Animica CAIP-19 profile][CAIP-19 Profile] - Asset identifiers in this namespace
+- [Animica source repository][] - Node, wallets, and specifications
+- [Chain Parameters][] - Chain ids, units, and network parameters
+- [HD Derivation][] - Normative BIP-39/SLIP-0010 to ML-DSA-65 derivation and address test vectors
+- [Public RPC][] - Public JSON-RPC 2.0 endpoint for mainnet (`POST https://rpc.animica.org/rpc`)
+- [Explorer][] - Mainnet block explorer
+- [PyPI package][] - `animica` Python package (node, CLI, and libraries)
+- [NonKYC market][] - Exchange where ANM trades (ANM/USDT)
+- [x402][] - Payment protocol whose Animica lane uses `animica:1` as its network id
+- [FIPS 204][] - Module-Lattice-Based Digital Signature Standard (ML-DSA)
+
+[Animica website]: https://animica.org
+[CAIP-2 Profile]: ./caip2.md
+[CAIP-10 Profile]: ./caip10.md
+[CAIP-19 Profile]: ./caip19.md
+[Animica source repository]: https://github.com/animicaorg/all
+[Chain Parameters]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/spec/CHAIN_PARAMS.md
+[HD Derivation]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/wallet/HD_DERIVATION.md
+[Public RPC]: https://rpc.animica.org/rpc
+[Explorer]: https://explorer.animica.org
+[PyPI package]: https://pypi.org/project/animica/
+[NonKYC market]: https://nonkyc.io/market/ANM_USDT
+[x402]: https://github.com/x402-foundation/x402
+[FIPS 204]: https://csrc.nist.gov/pubs/fips/204/final
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/animica/caip10.md
+++ b/animica/caip10.md
@@ -1,0 +1,189 @@
+---
+namespace-identifier: animica-caip10
+title: Animica Namespace - Addresses
+author: Animica (@animicaorg)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+status: Draft
+type: Standard
+created: 2026-08-22
+requires: ["CAIP-2", "CAIP-10"]
+---
+
+# CAIP-10
+
+*For context, see the [CAIP-10][] specification.*
+
+## Introduction
+
+An Animica account is identified by a bech32m ([BIP-350][]) string with the human-readable part `anim`, for example `anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7`.
+The encoded payload carries the id of the signature scheme that controls the account followed by a SHA3-256 digest of the account's public key, so the address format does not depend on the size of the post-quantum public key itself.
+An Animica CAIP-10 account id is the [CAIP-2][] chain id followed by a colon and the native address, unchanged.
+
+## Specification
+
+### Semantics
+
+The native address encodes a 34-byte payload:
+
+```text
+payload = u16be(alg_id) || SHA3-256(pubkey)
+```
+
+- `alg_id` is the 16-bit big-endian identifier of the signature scheme that controls the account.
+  User accounts use `0x1003`, ML-DSA-65 ([FIPS 204][]), which is the only scheme the network currently accepts signatures from.
+  Contract accounts use `0x0000`; they are keyless and their digest is derived from the deploying transaction rather than from a public key.
+  Validators accept `0x0000` or any value in `0x1000` through `0x1fff` so that contract, legacy, and future scheme ids remain addressable as transaction recipients.
+- `SHA3-256(pubkey)` is the NIST SHA3-256 digest (not Keccak-256) of the raw 1,952-byte ML-DSA-65 public key.
+
+The 32-byte digest is the account identity that transaction bodies carry; the `alg_id` prefix tells verifiers which scheme the accompanying signature must use.
+Only the way `pubkey` is produced and signatures are verified depends on the post-quantum scheme; the address encoding is scheme-agnostic.
+
+The same human-readable part `anim` is used on every Animica network.
+The chain id portion of the CAIP-10 identifier is therefore the only thing that distinguishes an account on mainnet from the same account on a test network.
+
+### Syntax
+
+```text
+account_id:      chain_id + ":" + account_address
+chain_id:        "animica:" + reference          (see the Animica CAIP-2 profile)
+account_address: "anim1" + data_chars + checksum_chars
+data_chars:      55 characters from the bech32 alphabet (34 bytes re-grouped into 5-bit words)
+checksum_chars:  6 characters from the bech32 alphabet (bech32m, constant 0x2bc830a3)
+```
+
+The native address is always exactly 66 characters long: the prefix `anim1`, 55 data characters, and 6 checksum characters.
+Because the first 15 bits of the payload are the upper bits of `alg_id`, every ML-DSA-65 account address begins with `anim1zqp` and every contract address begins with `anim1qqq`.
+
+Account identifiers MUST be lowercase.
+BIP-350 permits an all-uppercase encoding of the same address, but it is not canonical in this namespace and MUST be lowercased before use as a CAIP-10 identifier; mixed-case strings are invalid under BIP-350 and MUST be rejected.
+
+A validating regular expression for the native address:
+
+```regex
+^anim1[02-9ac-hj-np-z]{61}$
+```
+
+And for the fully-qualified account id:
+
+```regex
+^animica:(0|[1-9][0-9]{0,9}):anim1[02-9ac-hj-np-z]{61}$
+```
+
+A regular-expression match is necessary but not sufficient.
+Implementations MUST decode the string with the bech32m checksum constant `0x2bc830a3` (a plain bech32 checksum MUST be rejected), check that the decoded payload is exactly 34 bytes, and check that the leading `alg_id` is `0x0000` or in the range `0x1000` through `0x1fff`.
+
+### Resolution Mechanics
+
+A valid address does not need to have been seen on chain; querying an address that has never transacted simply returns a zero balance.
+To look up an account, call `state.getAccount` on an endpoint for the chain named in the identifier:
+
+```jsonc
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "state.getAccount",
+  "params": ["anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7"]
+}
+
+// Response (from a mainnet node, 2026-08-22)
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "address": "anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7",
+    "balance": "0x0"
+  }
+}
+```
+
+Balances are hexadecimal quantities in nano-ANM (1 ANM = 10^9 nANM).
+`state.getBalance` returns only the balance for the same input.
+Node views of transactions report `from` and `to` as the bare 32-byte digest in hexadecimal; to reconstruct the native address, prepend the account's `alg_id` and re-encode with bech32m.
+
+## Rationale
+
+The native address already carries a checksum, a fixed length, and the signature-scheme id, and it is the form that Animica's node, explorer, wallets, and payment lane exchange.
+Reusing it unchanged as the `account_address` keeps CAIP-10 identifiers copy-pasteable to and from every existing Animica interface.
+Lowercase is required so that each account has exactly one CAIP-10 string and identifiers can be compared byte-for-byte.
+
+### Backwards Compatibility
+
+There was no previously registered CAIP-10 profile for Animica.
+The address format described here is the one Animica has used since genesis, and this profile does not change it.
+
+## Test Cases
+
+The first three valid examples are the addresses derived from the BIP-39 reference mnemonic (`abandon` x 11, `about`) at the paths given, as published in the normative [HD Derivation][] document; they are real derived addresses and have zero balance on mainnet.
+
+### Valid identifiers
+
+```text
+# Mainnet, ML-DSA-65 account at m/44'/4279885'/0'/0'/0'
+animica:1:anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7
+
+# Mainnet, ML-DSA-65 account at m/44'/4279885'/0'/0'/1'
+animica:1:anim1zqpmznku3ddgyhl27d0p38jq7qyjgsnvafzd8pwh27gednh0x09s2egxyv9ej
+
+# Mainnet, ML-DSA-65 account at m/44'/4279885'/1'/0'/0'
+animica:1:anim1zqpn2j43cqempqfke6rzvwf6f4529xwrexgpcw8gfd8dg8agmcqw6qqu83f7t
+
+# Mainnet, contract-type address (alg_id 0x0000) with an all-zero digest; format illustration only
+animica:1:anim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3cshhr
+```
+
+### Invalid identifiers
+
+```text
+# Mixed case (invalid under BIP-350)
+animica:1:anim1ZQPN54YT2Fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7
+
+# All-uppercase encoding of the first valid example (decodes under BIP-350 but is not canonical here)
+animica:1:ANIM1ZQPN54YT2FZ07WG5ZZ33QPLKH7TEWV30TM5S9CDWVAG6KF6MYVD2D5SJ9PZP7
+
+# Same payload as the first valid example, encoded with the plain bech32 checksum instead of bech32m
+animica:1:anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5s8e3wyu
+
+# Last character corrupted (bech32m checksum fails)
+animica:1:anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzpq
+
+# Bare 32-byte digest in hexadecimal (the node's internal view, not an address)
+animica:1:0x3a548b5244ff391410a31007f6bf9797322f5ee902e1ae6751ab275b231aa6d2
+
+# Missing chain id
+anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7
+```
+
+## Security Considerations
+
+A regular-expression match alone does not establish that an address is valid; implementations MUST verify the bech32m checksum, the 34-byte payload length, and the `alg_id` range.
+A string that verifies only under the plain bech32 constant encodes the same payload but MUST be rejected, because the Animica node rejects it and accepting it would create two textual forms for one account.
+Because the human-readable part does not encode the network, applications MUST take the network from the CAIP-2 portion of the identifier and MUST NOT infer it from the address.
+
+## References
+
+- [CAIP-2][] - Blockchain ID specification
+- [CAIP-10][] - Account ID specification
+- [Animica CAIP-2 Profile][CAIP-2 Profile] - Chain identifiers in this namespace
+- [BIP-350][] - Bech32m format for native segwit version 1 outputs (the checksum used here)
+- [FIPS 204][] - Module-Lattice-Based Digital Signature Standard (ML-DSA)
+- [HD Derivation][] - Normative derivation and the address test vectors used above
+- [Address Implementation][] - Reference address encoder/decoder in the Animica wallet extension
+- [Node Address Implementation][] - Node-side Python address encoder/decoder
+- [Public RPC][] - Public JSON-RPC 2.0 endpoint for mainnet
+- [Explorer][] - Mainnet block explorer (`/address/{anim1...}`)
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-10]: https://chainagnostic.org/CAIPs/caip-10
+[CAIP-2 Profile]: ./caip2.md
+[BIP-350]: https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+[FIPS 204]: https://csrc.nist.gov/pubs/fips/204/final
+[HD Derivation]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/wallet/HD_DERIVATION.md
+[Address Implementation]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/apps/wallet-extension/src/core/crypto/address.ts
+[Node Address Implementation]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/pq/py/address.py
+[Public RPC]: https://rpc.animica.org/rpc
+[Explorer]: https://explorer.animica.org
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/animica/caip10.md
+++ b/animica/caip10.md
@@ -2,7 +2,7 @@
 namespace-identifier: animica-caip10
 title: Animica Namespace - Addresses
 author: Animica (@animicaorg)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/200
 status: Draft
 type: Standard
 created: 2026-08-22

--- a/animica/caip19.md
+++ b/animica/caip19.md
@@ -2,7 +2,7 @@
 namespace-identifier: animica-caip19
 title: Animica Namespace - Assets
 author: Animica (@animicaorg)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/200
 status: Draft
 type: Standard
 created: 2026-08-22

--- a/animica/caip19.md
+++ b/animica/caip19.md
@@ -1,0 +1,144 @@
+---
+namespace-identifier: animica-caip19
+title: Animica Namespace - Assets
+author: Animica (@animicaorg)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+status: Draft
+type: Standard
+created: 2026-08-22
+requires: ["CAIP-2", "CAIP-19", "CAIP-20"]
+---
+
+# CAIP-19
+
+*For context, see the [CAIP-19][] specification.*
+
+## Introduction
+
+Animica's native asset is ANM, the token in which transaction fees are paid and balances are denominated.
+This profile identifies ANM with the `slip44` asset namespace defined in [CAIP-20][], using Animica's SLIP-44 coin type.
+Assets issued by Animica's Python-VM smart contracts are not addressed by this revision; see the [Additional Considerations section](#additional-considerations).
+
+## Specification
+
+### Semantics
+
+The native asset of an Animica network is identified by the `slip44` asset namespace with coin type `4279885`.
+The coin type is `0x414E4D`, the ASCII encoding of `ANM`, and is the value Animica's normative [HD Derivation][] uses at the coin-type level of its BIP-44 path (`m/44'/4279885'/account'/0'/address_index'`).
+Registration of coin type `4279885` in the [SLIP-44][] registry is pending at the time of writing.
+
+ANM has 9 decimals: one ANM is 10^9 nano-ANM (nANM), and all node RPC quantities (balances, amounts, gas prices) are expressed in nANM.
+
+### Syntax
+
+```text
+asset_id:        chain_id + "/" + asset_namespace + ":" + asset_reference
+chain_id:        "animica:" + reference          (see the Animica CAIP-2 profile)
+asset_namespace: "slip44"
+asset_reference: "4279885"
+```
+
+A validating regular expression for the native asset on any Animica network:
+
+```regex
+^animica:(0|[1-9][0-9]{0,9})/slip44:4279885$
+```
+
+No other asset namespace or reference is defined by this revision.
+
+### Resolution Mechanics
+
+The native asset has no on-chain identifier to resolve; it is implied by the chain.
+To read an account's holding of the native asset, call `state.getBalance` with a native address on an endpoint for the chain named in the identifier:
+
+```jsonc
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "state.getBalance",
+  "params": ["anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7"]
+}
+
+// Response
+{ "jsonrpc": "2.0", "id": 1, "result": "0x0" }
+```
+
+The result is a hexadecimal quantity in nANM; divide by 10^9 to obtain ANM.
+A plain transfer of the native asset uses a gas limit of 21,000 at the gas price returned by `eth_gasPrice` (currently `0x1` nANM per gas on mainnet), so the fee is 21,000 nANM, or 0.000021 ANM.
+
+## Rationale
+
+Using the `slip44` asset namespace for the native asset follows [CAIP-20][] and the practice of other namespaces in this registry, and it reuses the coin type that Animica wallets already derive keys with.
+Pinning the reference to the single value `4279885` keeps the identifier unambiguous while the SLIP-44 registration is in progress.
+
+### Backwards Compatibility
+
+There was no previously registered CAIP-19 profile for Animica.
+This profile introduces no new on-chain identifiers.
+
+## Test Cases
+
+### Valid identifiers
+
+```text
+# ANM, the native asset of Animica mainnet
+animica:1/slip44:4279885
+
+# Native asset of the reference reserved for the public testnet
+animica:2/slip44:4279885
+```
+
+### Invalid identifiers
+
+```text
+# Wrong coin type (60 is Ethereum)
+animica:1/slip44:60
+
+# Ticker instead of coin type
+animica:1/slip44:ANM
+
+# Hexadecimal coin type
+animica:1/slip44:0x414e4d
+
+# Asset namespace not defined by this profile
+animica:1/erc20:anim1zqpn54yt2fz07wg5zz33qplkh7tewv30tm5s9cdwvag6kf6myvd2d5sj9pzp7
+
+# Contract-token form reserved for a future revision
+animica:1/contract:anim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3cshhr
+```
+
+## Additional Considerations
+
+Animica smart contracts run in a Python virtual machine and can issue their own assets.
+This revision deliberately defines only the native asset.
+An asset namespace for contract-issued tokens (for example `animica:1/contract:anim1...`) is reserved for a future revision, to be specified once there is a stable token interface in the Animica ecosystem to reference.
+Until then, identifiers using any asset namespace other than `slip44` MUST NOT be treated as valid under this profile.
+
+## References
+
+- [CAIP-2][] - Blockchain ID specification
+- [CAIP-19][] - Asset Type and Asset ID specification
+- [CAIP-20][] - Asset Reference for the SLIP44 Asset Namespace
+- [Animica CAIP-2 Profile][CAIP-2 Profile] - Chain identifiers in this namespace
+- [Animica CAIP-10 Profile][CAIP-10 Profile] - Account identifiers in this namespace
+- [SLIP-44][] - Registered coin types for BIP-0044
+- [HD Derivation][] - Normative derivation path using coin type `4279885` and the ANM unit definition
+- [Chain Parameters][] - Animica chain ids, units, and network parameters
+- [Public RPC][] - Public JSON-RPC 2.0 endpoint for mainnet
+- [NonKYC market][] - Exchange where ANM trades (ANM/USDT)
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[CAIP-19]: https://chainagnostic.org/CAIPs/caip-19
+[CAIP-20]: https://chainagnostic.org/CAIPs/caip-20
+[CAIP-2 Profile]: ./caip2.md
+[CAIP-10 Profile]: ./caip10.md
+[SLIP-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+[HD Derivation]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/wallet/HD_DERIVATION.md
+[Chain Parameters]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/spec/CHAIN_PARAMS.md
+[Public RPC]: https://rpc.animica.org/rpc
+[NonKYC market]: https://nonkyc.io/market/ANM_USDT
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/animica/caip2.md
+++ b/animica/caip2.md
@@ -2,7 +2,7 @@
 namespace-identifier: animica-caip2
 title: Animica Namespace - Chains
 author: Animica (@animicaorg)
-discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+discussions-to: https://github.com/ChainAgnostic/namespaces/pull/200
 status: Draft
 type: Standard
 created: 2026-08-22

--- a/animica/caip2.md
+++ b/animica/caip2.md
@@ -1,0 +1,157 @@
+---
+namespace-identifier: animica-caip2
+title: Animica Namespace - Chains
+author: Animica (@animicaorg)
+discussions-to: https://github.com/ChainAgnostic/namespaces/pulls
+status: Draft
+type: Standard
+created: 2026-08-22
+requires: CAIP-2
+---
+
+# CAIP-2
+
+*For context, see the [CAIP-2][] specification.*
+
+## Introduction
+
+Every Animica network is configured with an unsigned 32-bit integer chain id.
+The `animica` CAIP-2 profile identifies a network by encoding that value as a canonical unsigned decimal string.
+The mainnet identifier `animica:1` is already in production use by Animica's [x402][] ANM settlement lane and MCP tooling; this profile documents that existing usage.
+
+## Specification
+
+### Semantics
+
+An Animica chain id consists of the literal namespace `animica`, a colon, and a reference containing the network's integer chain id.
+The chain id is the value a node returns from `chain.getChainId`, and the `chainId` field of `chain.getChainIdentity`, `chain.getHead`, and every block and transaction view.
+The same chain id is committed to in the signing domain of every transaction, so a transaction signed for one chain id is not valid on a network with a different one.
+
+Animica's [chain parameters][Chain Parameters] assign `1` to mainnet, `2` to the public testnet, and `1337` to local development networks.
+Only the mainnet (`animica:1`) is a public network with a public RPC endpoint at the time of writing.
+
+### Syntax
+
+```text
+chain_id:  "animica:" + reference
+namespace: animica
+reference: 0 | [1-9][0-9]{0,9}
+```
+
+The reference must match the following regular expression:
+
+```regex
+^(0|[1-9][0-9]{0,9})$
+```
+
+The parsed value must additionally be in the unsigned 32-bit integer range `0` through `4294967295`, inclusive; the regular expression alone is not sufficient to enforce the upper bound.
+The reference uses ASCII decimal digits without a sign, base prefix, separators, surrounding whitespace, or leading zeroes.
+The value `0` is syntactically representable but is not assigned to any Animica network and has no special meaning; applications SHOULD NOT use it.
+
+### Resolution Mechanics
+
+To resolve the chain id reported by an Animica JSON-RPC endpoint, call `chain.getChainId`:
+
+```jsonc
+// Request
+{ "jsonrpc": "2.0", "id": 1, "method": "chain.getChainId", "params": [] }
+
+// Response
+{ "jsonrpc": "2.0", "id": 1, "result": 1 }
+```
+
+Serialize the result in canonical unsigned decimal form and prefix it with `animica:`.
+The example response therefore resolves to `animica:1`.
+
+An integer chain id does not by itself prove which chain an endpoint serves, because a future or private network could be configured with the same value.
+Clients that need a trusted chain identity SHOULD instead call `chain.getChainIdentity`, which returns the chain id together with the genesis hash and the fork id that the network's signing domain commits to:
+
+```jsonc
+// Request
+{ "jsonrpc": "2.0", "id": 1, "method": "chain.getChainIdentity", "params": [] }
+
+// Response (from a mainnet node, 2026-08-22)
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "chainId": 1,
+    "genesisHash": "0xa0892158cf997c56e91d0aa12e60c36037dae34800a2b54111a8fa17ec88b7de",
+    "genesisHeaderHash": "0xa0892158cf997c56e91d0aa12e60c36037dae34800a2b54111a8fa17ec88b7de",
+    "genesisBlockHash": "0xa0892158cf997c56e91d0aa12e60c36037dae34800a2b54111a8fa17ec88b7de",
+    "forkId": 3511060514,
+    "consensusId": "consensus/68e4e2ad4c547dce744181cedeabe028920cae052eb8095a6f18d351bf68dc74",
+    "protocolVersion": "1.0"
+  }
+}
+```
+
+For `animica:1`, clients SHOULD verify that `genesisHash` equals `0xa0892158cf997c56e91d0aa12e60c36037dae34800a2b54111a8fa17ec88b7de` before treating the endpoint as Animica mainnet.
+The `forkId` (`3511060514` on mainnet) is part of the transaction signing domain and changes with protocol upgrades, so it should be read from the node at signing time rather than hard-coded as a chain identifier.
+
+## Rationale
+
+The integer chain id is the native network discriminator in Animica's chain parameters, is exposed directly by the standard JSON-RPC interface, and is bound into every transaction signature.
+Using it requires no additional registry or transformation and matches the `animica:<chainId>` form that Animica's own documentation, payment lane, and tooling already use.
+
+Decimal encoding matches the JSON-RPC representation and avoids multiple textual forms for the same value, such as hexadecimal, signed, or zero-padded representations.
+The genesis-hash cross-check described above follows the precedent of other namespaces whose chain references are operator-configurable integers and exist to defeat a later chain reusing the same id.
+
+### Backwards Compatibility
+
+There was no previously registered CAIP-2 profile for Animica.
+This profile does not change Animica's native chain ids.
+The identifier `animica:1` is already in use by deployed Animica software, and this profile is compatible with that usage.
+
+## Test Cases
+
+### Valid identifiers
+
+| Identifier | Reason |
+| --- | --- |
+| `animica:1` | Animica mainnet (genesis 2026-04-06, public RPC `https://rpc.animica.org/rpc`) |
+| `animica:2` | Reference reserved for the public testnet in the chain parameters |
+| `animica:1337` | Reference reserved for local development networks |
+| `animica:4294967295` | Upper `uint32` boundary |
+
+### Invalid identifiers
+
+| Identifier | Reason |
+| --- | --- |
+| `animica:` | Empty reference |
+| `animica:01` | Leading zero |
+| `animica:0x1` | Hexadecimal representation |
+| `animica:-1` | Signed value |
+| `animica:mainnet` | Reference must be the decimal chain id, not a name |
+| `animica:4294967296` | Above the `uint32` maximum |
+| `animica: 1` | Leading whitespace |
+| `ANIMICA:1` | Incorrect namespace casing |
+| `eip155:1` | Ethereum mainnet; Animica is not an `eip155` chain even though its chain id is also `1` |
+
+## Security Considerations
+
+Resolving a chain id through `chain.getChainId` only establishes what the queried endpoint reports.
+It does not authenticate that endpoint or prevent another network from being configured with the same integer.
+Applications that rely on a trusted chain identity should corroborate the result with the `genesisHash` returned by `chain.getChainIdentity`, as described in the [Resolution Mechanics section](#resolution-mechanics).
+
+## References
+
+- [CAIP-2][] - Blockchain ID specification
+- [Chain Parameters][] - Animica chain ids, units, and network parameters
+- [Encoding Specification][] - Defines `chainId` as a `u32` and lists the registered ids
+- [Public RPC][] - Public JSON-RPC 2.0 endpoint for mainnet
+- [Explorer][] - Mainnet block explorer
+- [Animica source repository][] - Node and reference implementations
+- [x402][] - Payment protocol whose Animica lane uses `animica:1` as its network id
+
+[CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
+[Chain Parameters]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/spec/CHAIN_PARAMS.md
+[Encoding Specification]: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/spec/ENCODING.md
+[Public RPC]: https://rpc.animica.org/rpc
+[Explorer]: https://explorer.animica.org
+[Animica source repository]: https://github.com/animicaorg/all
+[x402]: https://github.com/x402-foundation/x402
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

This PR adds the `animica` namespace with CAIP-2, CAIP-10, and CAIP-19 profiles.

[Animica](https://animica.org) is a live proof-of-work Layer 1 whose accounts sign with post-quantum ML-DSA-65 (FIPS 204) signatures and whose smart contracts run in a Python VM. Mainnet has been running since 2026-04-06 (chain id `1`, genesis `0xa0892158cf997c56e91d0aa12e60c36037dae34800a2b54111a8fa17ec88b7de`). The native token ANM has 9 decimals.

## Motivation

The identifier `animica:1` is already in production use today: Animica's [x402](https://github.com/x402-foundation/x402) ANM settlement lane uses it as its network id, as do its MCP tooling and chain parameters. This is the same situation as the `bsv` (#190) and `kaspa` (#193) submissions, where a payment protocol was already exchanging a CAIP-2 identifier and the namespace registration documents it. Wallets and dapps integrating Animica need CAIP-2/10/19 identifiers they can rely on rather than each inventing their own.

Animica cannot live in `eip155`: it is not an EVM chain, its addresses are bech32m strings carrying a signature-scheme id and a SHA3-256 key digest, its transactions are canonical CBOR signed with ML-DSA-65, and its chain id `1` would collide with Ethereum mainnet.

## What each document defines

- **`animica/README.md`** - namespace overview, why it is not `eip155`, governance, and a resources list (website, explorer, public RPC, source, PyPI, normative HD-derivation doc, exchange listing).
- **`animica/caip2.md`** - `animica:<chainId>`; reference is the canonical decimal of the node's `uint32` chain id (`^(0|[1-9][0-9]{0,9})$`, bounded to `uint32`, `0` unassigned). Resolution via `chain.getChainId`, and a genesis-hash cross-check via `chain.getChainIdentity` (live response included) so a future chain reusing the id cannot be mistaken for mainnet. Valid/invalid test tables. `animica:2` (testnet) and `animica:1337` (devnet) are noted as reserved; only mainnet is public today.
- **`animica/caip10.md`** - `animica:1:anim1...`; the native address is bech32m (BIP-350, HRP `anim`, constant `0x2bc830a3`) over a 34-byte payload `u16be(alg_id) || SHA3-256(pubkey)`. Always 66 characters; ML-DSA-65 accounts (`0x1003`) start `anim1zqp`, contract addresses (`0x0000`) start `anim1qqq`. Lowercase is canonical. Regex `^anim1[02-9ac-hj-np-z]{61}$` plus checksum/length/alg-range validation. Test vectors are the three real addresses from the BIP-39 reference mnemonic in the normative HD derivation document, plus negatives (mixed case, uppercase, plain-bech32 checksum of the same payload, corrupted checksum, bare hex digest).
- **`animica/caip19.md`** - native asset `animica:1/slip44:4279885` (coin type `0x414E4D` = ASCII `ANM`, 9 decimals). SLIP-44 registration is **pending** (a PR to satoshilabs/slips is being filed alongside this one). Contract-issued tokens are explicitly reserved for a future revision rather than specified loosely.

## How it was verified

- Frontmatter of all four files parsed with PyYAML; every `[Name][]` alias resolves and none is unused; no inline external links; one sentence per line.
- Every CAIP-10 test vector was re-derived independently in Python: `SHA3-256(pubkey)` matches the published digest, bech32m encoding of `0x1003 || digest` reproduces each address byte-for-byte, each decodes with the bech32m constant to a 34-byte payload with `alg_id = 0x1003`, and each matches the regex. Each negative vector fails for exactly the stated reason (the plain-bech32 variant verifies under constant `1` and fails under `0x2bc830a3`).
- Every CAIP-2 and CAIP-19 valid/invalid identifier was checked against the profile regexes and the `uint32` bound.
- The `chain.getChainId`, `chain.getChainIdentity`, and `state.getAccount` responses shown in the profiles were captured live from `https://rpc.animica.org/rpc` on 2026-08-22.
- `bundle exec jekyll build` was not run: Ruby/Bundler are not available in the authoring environment. The pages use only the same frontmatter keys as the existing `neo`, `bsv`, and `stellar` profiles, and the site auto-discovers the `animica/` directory.

## Links

- Website: https://animica.org
- Explorer: https://explorer.animica.org
- Public RPC: `POST https://rpc.animica.org/rpc`
- Source: https://github.com/animicaorg/all
- PyPI: https://pypi.org/project/animica/
- HD derivation (normative, with the address test vectors): https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/wallet/HD_DERIVATION.md
- ANM trades on NonKYC: https://nonkyc.io/market/ANM_USDT

HD path: `m/44'/4279885'/account'/0'/address_index'` (all hardened, SLIP-0010 ed25519-family derivation; the final 32-byte key is the ML-DSA-65 seed).

## Known limitations

- The SLIP-44 coin type `4279885` is not yet in the registry; the CAIP-19 profile says so.
- Contract-token asset references are deliberately out of scope for this revision.
- `discussions-to` points at this PR, following the precedent of `bsv`, `stellar`, and `xync`.

@bumblefudge @obstropolos when you have a moment, an editorial review would be much appreciated - thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mj19WF7SsZ4sSkaNat12rq
